### PR TITLE
refactor: add `GeneratePodTemplateSpec()` to generate the skeleton of corev1.PodTemplateSpec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ MANIFESTS_DIR = ./manifests
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.1
 
+GOLANGCI_LINT_VERSION = v1.50.1
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -78,7 +80,7 @@ fmt: ## Run go fmt against code.
 
 .PHONY: install-golint
 install-golint: ## Install golint
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@master
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
 
 .PHONY: lint
 lint: install-golint ## Run golint

--- a/apis/v1alpha1/greptimedbcluster_types.go
+++ b/apis/v1alpha1/greptimedbcluster_types.go
@@ -131,7 +131,7 @@ type SlimPodSpec struct {
 	// Default to false.
 	// HostNetwork field is from 'corev1.PodSpec.HostNetwork'.
 	// +optional
-	HostNetwork *bool `json:"hostNetwork,omitempty"`
+	HostNetwork bool `json:"hostNetwork,omitempty"`
 
 	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
 	// If specified, these secrets will be passed to individual puller implementations for them to use.
@@ -200,11 +200,6 @@ type MainContainerSpec struct {
 	// +optional
 	WorkingDir string `json:"workingDir,omitempty"`
 
-	// Pod volumes to mount into the container's filesystem.
-	// VolumeMounts field is from 'corev1.Container.VolumeMounts'.
-	// +optional
-	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
-
 	// List of environment variables to set in the container.
 	// Cannot be updated.
 	// Env field is from 'corev1.Container.Env'.
@@ -238,7 +233,7 @@ type MainContainerSpec struct {
 	// More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
 	// ImagePullPolicy field is from 'corev1.Container.ImagePullPolicy'.
 	// +optional
-	ImagePullPolicy *corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 }
 
 // PodTemplateSpec defines the template for a pod of cluster.

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -282,13 +282,6 @@ func (in *MainContainerSpec) DeepCopyInto(out *MainContainerSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.VolumeMounts != nil {
-		in, out := &in.VolumeMounts, &out.VolumeMounts
-		*out = make([]v1.VolumeMount, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
-	}
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]v1.EnvVar, len(*in))
@@ -310,11 +303,6 @@ func (in *MainContainerSpec) DeepCopyInto(out *MainContainerSpec) {
 		in, out := &in.Lifecycle, &out.Lifecycle
 		*out = new(v1.Lifecycle)
 		(*in).DeepCopyInto(*out)
-	}
-	if in.ImagePullPolicy != nil {
-		in, out := &in.ImagePullPolicy, &out.ImagePullPolicy
-		*out = new(v1.PullPolicy)
-		**out = **in
 	}
 }
 
@@ -463,11 +451,6 @@ func (in *SlimPodSpec) DeepCopyInto(out *SlimPodSpec) {
 	if in.ActiveDeadlineSeconds != nil {
 		in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
 		*out = new(int64)
-		**out = **in
-	}
-	if in.HostNetwork != nil {
-		in, out := &in.HostNetwork, &out.HostNetwork
-		*out = new(bool)
 		**out = **in
 	}
 	if in.ImagePullSecrets != nil {

--- a/config/crd/bases/greptime.io_greptimedbclusters.yaml
+++ b/config/crd/bases/greptime.io_greptimedbclusters.yaml
@@ -1949,26 +1949,6 @@ spec:
                               x-kubernetes-int-or-string: true
                             type: object
                         type: object
-                      volumeMounts:
-                        items:
-                          properties:
-                            mountPath:
-                              type: string
-                            mountPropagation:
-                              type: string
-                            name:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            subPath:
-                              type: string
-                            subPathExpr:
-                              type: string
-                          required:
-                          - mountPath
-                          - name
-                          type: object
-                        type: array
                       workingDir:
                         type: string
                     type: object
@@ -3916,26 +3896,6 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 type: object
                             type: object
-                          volumeMounts:
-                            items:
-                              properties:
-                                mountPath:
-                                  type: string
-                                mountPropagation:
-                                  type: string
-                                name:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                subPath:
-                                  type: string
-                                subPathExpr:
-                                  type: string
-                              required:
-                              - mountPath
-                              - name
-                              type: object
-                            type: array
                           workingDir:
                             type: string
                         type: object
@@ -5890,26 +5850,6 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 type: object
                             type: object
-                          volumeMounts:
-                            items:
-                              properties:
-                                mountPath:
-                                  type: string
-                                mountPropagation:
-                                  type: string
-                                name:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                subPath:
-                                  type: string
-                                subPathExpr:
-                                  type: string
-                              required:
-                              - mountPath
-                              - name
-                              type: object
-                            type: array
                           workingDir:
                             type: string
                         type: object
@@ -7860,26 +7800,6 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 type: object
                             type: object
-                          volumeMounts:
-                            items:
-                              properties:
-                                mountPath:
-                                  type: string
-                                mountPropagation:
-                                  type: string
-                                name:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                subPath:
-                                  type: string
-                                subPathExpr:
-                                  type: string
-                              required:
-                              - mountPath
-                              - name
-                              type: object
-                            type: array
                           workingDir:
                             type: string
                         type: object

--- a/manifests/greptimedb-operator-crd.yaml
+++ b/manifests/greptimedb-operator-crd.yaml
@@ -1948,26 +1948,6 @@ spec:
                               x-kubernetes-int-or-string: true
                             type: object
                         type: object
-                      volumeMounts:
-                        items:
-                          properties:
-                            mountPath:
-                              type: string
-                            mountPropagation:
-                              type: string
-                            name:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            subPath:
-                              type: string
-                            subPathExpr:
-                              type: string
-                          required:
-                          - mountPath
-                          - name
-                          type: object
-                        type: array
                       workingDir:
                         type: string
                     type: object
@@ -3915,26 +3895,6 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 type: object
                             type: object
-                          volumeMounts:
-                            items:
-                              properties:
-                                mountPath:
-                                  type: string
-                                mountPropagation:
-                                  type: string
-                                name:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                subPath:
-                                  type: string
-                                subPathExpr:
-                                  type: string
-                              required:
-                              - mountPath
-                              - name
-                              type: object
-                            type: array
                           workingDir:
                             type: string
                         type: object
@@ -5889,26 +5849,6 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 type: object
                             type: object
-                          volumeMounts:
-                            items:
-                              properties:
-                                mountPath:
-                                  type: string
-                                mountPropagation:
-                                  type: string
-                                name:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                subPath:
-                                  type: string
-                                subPathExpr:
-                                  type: string
-                              required:
-                              - mountPath
-                              - name
-                              type: object
-                            type: array
                           workingDir:
                             type: string
                         type: object
@@ -7859,26 +7799,6 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 type: object
                             type: object
-                          volumeMounts:
-                            items:
-                              properties:
-                                mountPath:
-                                  type: string
-                                mountPropagation:
-                                  type: string
-                                name:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                subPath:
-                                  type: string
-                                subPathExpr:
-                                  type: string
-                              required:
-                              - mountPath
-                              - name
-                              type: object
-                            type: array
                           workingDir:
                             type: string
                         type: object

--- a/manifests/greptimedb-operator-deployment.yaml
+++ b/manifests/greptimedb-operator-deployment.yaml
@@ -1955,26 +1955,6 @@ spec:
                               x-kubernetes-int-or-string: true
                             type: object
                         type: object
-                      volumeMounts:
-                        items:
-                          properties:
-                            mountPath:
-                              type: string
-                            mountPropagation:
-                              type: string
-                            name:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            subPath:
-                              type: string
-                            subPathExpr:
-                              type: string
-                          required:
-                          - mountPath
-                          - name
-                          type: object
-                        type: array
                       workingDir:
                         type: string
                     type: object
@@ -3922,26 +3902,6 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 type: object
                             type: object
-                          volumeMounts:
-                            items:
-                              properties:
-                                mountPath:
-                                  type: string
-                                mountPropagation:
-                                  type: string
-                                name:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                subPath:
-                                  type: string
-                                subPathExpr:
-                                  type: string
-                              required:
-                              - mountPath
-                              - name
-                              type: object
-                            type: array
                           workingDir:
                             type: string
                         type: object
@@ -5896,26 +5856,6 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 type: object
                             type: object
-                          volumeMounts:
-                            items:
-                              properties:
-                                mountPath:
-                                  type: string
-                                mountPropagation:
-                                  type: string
-                                name:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                subPath:
-                                  type: string
-                                subPathExpr:
-                                  type: string
-                              required:
-                              - mountPath
-                              - name
-                              type: object
-                            type: array
                           workingDir:
                             type: string
                         type: object
@@ -7866,26 +7806,6 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 type: object
                             type: object
-                          volumeMounts:
-                            items:
-                              properties:
-                                mountPath:
-                                  type: string
-                                mountPropagation:
-                                  type: string
-                                name:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                subPath:
-                                  type: string
-                                subPathExpr:
-                                  type: string
-                              required:
-                              - mountPath
-                              - name
-                              type: object
-                            type: array
                           workingDir:
                             type: string
                         type: object


### PR DESCRIPTION
- Add `GeneratePodTemplateSpec()` to generate PodTemplateSpec;
- Move the generation of podtemplatespec into the new function `generatePodTemplateSpec()` of deployers;
- Modify type of some fields(`HostNetwork` and `ImagePullPolicy`) of GreptimeDBCluster to fit the origin schema of corev1.PodTemplateSpec;
- Specify version of golangci-lint by GOLANGCI_LINT_VERSION in Makefile;