### PR TITLE
refactor: expand default cpu and memory arguments and make 'request == limit'

### DIFF
--- a/apis/v1alpha1/defaulting.go
+++ b/apis/v1alpha1/defaulting.go
@@ -24,10 +24,8 @@ import (
 )
 
 var (
-	defaultRequestCPU    = "250m"
-	defaultRequestMemory = "64Mi"
-	defaultLimitCPU      = "500m"
-	defaultLimitMemory   = "128Mi"
+	defaultCPU    = "500m"
+	defaultMemory = "512Mi"
 
 	defaultVersion = "Unknown"
 
@@ -58,13 +56,14 @@ func (in *GreptimeDBCluster) SetDefaults() error {
 		Base: &PodTemplateSpec{
 			MainContainer: &MainContainerSpec{
 				Resources: &corev1.ResourceRequirements{
+					// Let Requests == Limits by default.
 					Requests: map[corev1.ResourceName]resource.Quantity{
-						"cpu":    resource.MustParse(defaultRequestCPU),
-						"memory": resource.MustParse(defaultRequestMemory),
+						"cpu":    resource.MustParse(defaultCPU),
+						"memory": resource.MustParse(defaultMemory),
 					},
 					Limits: map[corev1.ResourceName]resource.Quantity{
-						"cpu":    resource.MustParse(defaultLimitCPU),
-						"memory": resource.MustParse(defaultLimitMemory),
+						"cpu":    resource.MustParse(defaultCPU),
+						"memory": resource.MustParse(defaultMemory),
 					},
 				},
 

--- a/apis/v1alpha1/defaulting_test.go
+++ b/apis/v1alpha1/defaulting_test.go
@@ -62,12 +62,12 @@ func TestSetDefaults(t *testing.T) {
 							Image: "greptime/greptimedb:latest",
 							Resources: &corev1.ResourceRequirements{
 								Requests: map[corev1.ResourceName]resource.Quantity{
-									"cpu":    resource.MustParse(defaultRequestCPU),
-									"memory": resource.MustParse(defaultRequestMemory),
+									"cpu":    resource.MustParse(defaultCPU),
+									"memory": resource.MustParse(defaultMemory),
 								},
 								Limits: map[corev1.ResourceName]resource.Quantity{
-									"cpu":    resource.MustParse(defaultLimitCPU),
-									"memory": resource.MustParse(defaultLimitMemory),
+									"cpu":    resource.MustParse(defaultCPU),
+									"memory": resource.MustParse(defaultMemory),
 								},
 							},
 							ReadinessProbe: &corev1.Probe{
@@ -88,12 +88,12 @@ func TestSetDefaults(t *testing.T) {
 									Image: "greptime/greptimedb:latest",
 									Resources: &corev1.ResourceRequirements{
 										Requests: map[corev1.ResourceName]resource.Quantity{
-											"cpu":    resource.MustParse(defaultRequestCPU),
-											"memory": resource.MustParse(defaultRequestMemory),
+											"cpu":    resource.MustParse(defaultCPU),
+											"memory": resource.MustParse(defaultMemory),
 										},
 										Limits: map[corev1.ResourceName]resource.Quantity{
-											"cpu":    resource.MustParse(defaultLimitCPU),
-											"memory": resource.MustParse(defaultLimitMemory),
+											"cpu":    resource.MustParse(defaultCPU),
+											"memory": resource.MustParse(defaultMemory),
 										},
 									},
 									ReadinessProbe: &corev1.Probe{
@@ -119,12 +119,12 @@ func TestSetDefaults(t *testing.T) {
 									Image: "greptime/greptimedb:latest",
 									Resources: &corev1.ResourceRequirements{
 										Requests: map[corev1.ResourceName]resource.Quantity{
-											"cpu":    resource.MustParse(defaultRequestCPU),
-											"memory": resource.MustParse(defaultRequestMemory),
+											"cpu":    resource.MustParse(defaultCPU),
+											"memory": resource.MustParse(defaultMemory),
 										},
 										Limits: map[corev1.ResourceName]resource.Quantity{
-											"cpu":    resource.MustParse(defaultLimitCPU),
-											"memory": resource.MustParse(defaultLimitMemory),
+											"cpu":    resource.MustParse(defaultCPU),
+											"memory": resource.MustParse(defaultMemory),
 										},
 									},
 									ReadinessProbe: &corev1.Probe{
@@ -148,12 +148,12 @@ func TestSetDefaults(t *testing.T) {
 									Image: "greptime/greptimedb:latest",
 									Resources: &corev1.ResourceRequirements{
 										Requests: map[corev1.ResourceName]resource.Quantity{
-											"cpu":    resource.MustParse(defaultRequestCPU),
-											"memory": resource.MustParse(defaultRequestMemory),
+											"cpu":    resource.MustParse(defaultCPU),
+											"memory": resource.MustParse(defaultMemory),
 										},
 										Limits: map[corev1.ResourceName]resource.Quantity{
-											"cpu":    resource.MustParse(defaultLimitCPU),
-											"memory": resource.MustParse(defaultLimitMemory),
+											"cpu":    resource.MustParse(defaultCPU),
+											"memory": resource.MustParse(defaultMemory),
 										},
 									},
 									ReadinessProbe: &corev1.Probe{
@@ -414,12 +414,12 @@ func TestSetDefaults(t *testing.T) {
 							Image: "greptime/greptimedb:latest",
 							Resources: &corev1.ResourceRequirements{
 								Requests: map[corev1.ResourceName]resource.Quantity{
-									"cpu":    resource.MustParse(defaultRequestCPU),
-									"memory": resource.MustParse(defaultRequestMemory),
+									"cpu":    resource.MustParse(defaultCPU),
+									"memory": resource.MustParse(defaultMemory),
 								},
 								Limits: map[corev1.ResourceName]resource.Quantity{
-									"cpu":    resource.MustParse(defaultLimitCPU),
-									"memory": resource.MustParse(defaultLimitMemory),
+									"cpu":    resource.MustParse(defaultCPU),
+									"memory": resource.MustParse(defaultMemory),
 								},
 							},
 							ReadinessProbe: &corev1.Probe{
@@ -440,12 +440,12 @@ func TestSetDefaults(t *testing.T) {
 									Image: "greptime/greptimedb:latest",
 									Resources: &corev1.ResourceRequirements{
 										Requests: map[corev1.ResourceName]resource.Quantity{
-											"cpu":    resource.MustParse(defaultRequestCPU),
-											"memory": resource.MustParse(defaultRequestMemory),
+											"cpu":    resource.MustParse(defaultCPU),
+											"memory": resource.MustParse(defaultMemory),
 										},
 										Limits: map[corev1.ResourceName]resource.Quantity{
-											"cpu":    resource.MustParse(defaultLimitCPU),
-											"memory": resource.MustParse(defaultLimitMemory),
+											"cpu":    resource.MustParse(defaultCPU),
+											"memory": resource.MustParse(defaultMemory),
 										},
 									},
 									ReadinessProbe: &corev1.Probe{


### PR DESCRIPTION
The original CPU and memory settings are too small, and it may easily lead to some problem like OOMKilled.