### PR TITLE
ci: update title checker rule

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -4,7 +4,9 @@
     "color": "B60205"
   },
   "CHECKS": {
-    "regexp": "^(feat|fix|test|refactor|chore|style|docs|perf|build|ci|revert)(\\(.*\\))?:.*",
-    "ignoreLabels" : ["ignore-title"]
+    "regexp": "^(feat|fix|test|refactor|chore|style|docs|perf|build|ci|revert)(\\(.*\\))?\\!?:.*",
+    "ignoreLabels": [
+      "ignore-title"
+    ]
   }
 }


### PR DESCRIPTION
The config is synced from 'https://github.com/GreptimeTeam/greptimedb/blob/develop/.github/pr-title-checker-config.json'.