### PR TITLE
chore: use `--metasrv-addrs` instead

### DIFF
--- a/apis/v1alpha1/defaulting_test.go
+++ b/apis/v1alpha1/defaulting_test.go
@@ -211,7 +211,7 @@ func TestSetDefaults(t *testing.T) {
 								MainContainer: &MainContainerSpec{
 									Image: "greptime/frontend:latest",
 									Args: []string{
-										"--metasrv-addr",
+										"--metasrv-addrs",
 										"meta.default:3002",
 									},
 								},
@@ -278,7 +278,7 @@ func TestSetDefaults(t *testing.T) {
 								MainContainer: &MainContainerSpec{
 									Image: "greptime/frontend:latest",
 									Args: []string{
-										"--metasrv-addr",
+										"--metasrv-addrs",
 										"meta.default:3002",
 									},
 									Resources: &corev1.ResourceRequirements{

--- a/controllers/greptimedbcluster/deployers/datanode.go
+++ b/controllers/greptimedbcluster/deployers/datanode.go
@@ -284,7 +284,7 @@ func (b *datanodeBuilder) BuildPodMonitor() deployer.Builder {
 func (b *datanodeBuilder) generateMainContainerArgs() []string {
 	return []string{
 		"datanode", "start",
-		"--metasrv-addr", fmt.Sprintf("%s.%s:%d", common.ResourceName(b.Cluster.Name, v1alpha1.MetaComponentKind),
+		"--metasrv-addrs", fmt.Sprintf("%s.%s:%d", common.ResourceName(b.Cluster.Name, v1alpha1.MetaComponentKind),
 			b.Cluster.Namespace, b.Cluster.Spec.Meta.ServicePort),
 		// TODO(zyy17): Should we add the new field of the CRD for datanode http port?
 		"--http-addr", fmt.Sprintf("0.0.0.0:%d", b.Cluster.Spec.HTTPServicePort),

--- a/controllers/greptimedbcluster/deployers/frontend.go
+++ b/controllers/greptimedbcluster/deployers/frontend.go
@@ -243,7 +243,7 @@ func (b *frontendBuilder) generateMainContainerArgs() []string {
 	var args = []string{
 		"frontend", "start",
 		"--rpc-addr", fmt.Sprintf("0.0.0.0:%d", b.Cluster.Spec.GRPCServicePort),
-		"--metasrv-addr", fmt.Sprintf("%s.%s:%d", common.ResourceName(b.Cluster.Name, v1alpha1.MetaComponentKind),
+		"--metasrv-addrs", fmt.Sprintf("%s.%s:%d", common.ResourceName(b.Cluster.Name, v1alpha1.MetaComponentKind),
 			b.Cluster.Namespace, b.Cluster.Spec.Meta.ServicePort),
 		"--http-addr", fmt.Sprintf("0.0.0.0:%d", b.Cluster.Spec.HTTPServicePort),
 		"--mysql-addr", fmt.Sprintf("0.0.0.0:%d", b.Cluster.Spec.MySQLServicePort),


### PR DESCRIPTION
use `--metasrv-addrs` instead of `--metasrv-addr` which latter is a soon to be deprecated option 