### PR TITLE
fix(e2e): wait for the CRDs to be created and specify ts column in insert test case

### DIFF
--- a/tests/e2e/setup/create-cluster.sh
+++ b/tests/e2e/setup/create-cluster.sh
@@ -179,6 +179,20 @@ function deploy_kafka_cluster() {
   echo -e "${GREEN}=> Deploy Kafka cluster...${RESET}"
   kubectl create namespace "$KAFKA_NAMESPACE"
   kubectl create -f "https://strimzi.io/install/latest?namespace=$KAFKA_NAMESPACE" -n "$KAFKA_NAMESPACE"
+
+  # Wait for the CRDs to be created.
+  kubectl wait \
+    --for=condition=Established \
+    crd/kafkabridges.kafka.strimzi.io \
+    crd/kafkaconnects.kafka.strimzi.io \
+    crd/kafkamirrormakers.kafka.strimzi.io \
+    crd/kafkanodepools.kafka.strimzi.io \
+    crd/kafkarebalances.kafka.strimzi.io \
+    crd/kafkas.kafka.strimzi.io \
+    crd/kafkatopics.kafka.strimzi.io \
+    crd/kafkausers.kafka.strimzi.io \
+    --timeout="$DEFAULT_TIMEOUT"
+
   kubectl apply -f ./tests/e2e/setup/kafka-wal.yaml -n "$KAFKA_NAMESPACE"
   echo -e "${GREEN}<= Kafka cluster is deployed.${RESET}"
 }

--- a/tests/e2e/utils/utils.go
+++ b/tests/e2e/utils/utils.go
@@ -134,7 +134,7 @@ func RunSQLTest(ctx context.Context, frontendIngressIP string, isDistributed boo
 	}
 
 	const (
-		createDistributedTableSQL = `CREATE TABLE dist_table(
+		createDistributedTableSQL = `CREATE TABLE test_table(
 							ts TIMESTAMP DEFAULT current_timestamp(),
 							n INT,
 							row_id INT,
@@ -148,7 +148,7 @@ func RunSQLTest(ctx context.Context, frontendIngressIP string, isDistributed boo
 						  )
 						  engine=mito;`
 
-		createStandaloneTableSQL = `CREATE TABLE dist_table(
+		createStandaloneTableSQL = `CREATE TABLE test_table(
 							ts TIMESTAMP DEFAULT current_timestamp(),
 							n INT,
 							row_id INT,
@@ -157,8 +157,8 @@ func RunSQLTest(ctx context.Context, frontendIngressIP string, isDistributed boo
 						  )
 						  engine=mito;`
 
-		insertDataSQL = `INSERT INTO dist_table(n, row_id) VALUES (?, ?);`
-		selectDataSQL = `SELECT * FROM dist_table`
+		insertDataSQL = `INSERT INTO test_table(n, row_id, ts) VALUES (?, ?, ?);`
+		selectDataSQL = `SELECT * FROM test_table`
 
 		rowsNum = 42
 	)
@@ -174,7 +174,9 @@ func RunSQLTest(ctx context.Context, frontendIngressIP string, isDistributed boo
 	}
 
 	for i := 0; i < rowsNum; i++ {
-		_, err = conn.ExecContext(ctx, insertDataSQL, i, i)
+		now := time.Now()
+		timestampInMillisecond := now.Unix()*1000 + int64(now.Nanosecond())/1e6
+		_, err = conn.ExecContext(ctx, insertDataSQL, i, i, timestampInMillisecond)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## What's changed

1. Add the waiting process for adding CRDs;
2. Specify `ts` column in insert statement(I think it's a incompatible modification in GreptimeDB);
