### PR TITLE
refactor!(api): refine the default setting of `*port` field of cluster

### DIFF
--- a/apis/v1alpha1/defaulting_test.go
+++ b/apis/v1alpha1/defaulting_test.go
@@ -15,516 +15,71 @@
 package v1alpha1
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
-	"google.golang.org/protobuf/proto"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/util/intstr"
+	"github.com/sergi/go-diff/diffmatchpatch"
+	"sigs.k8s.io/yaml"
 )
 
-func TestSetDefaults(t *testing.T) {
-	tests := []struct {
-		input GreptimeDBCluster
-		want  GreptimeDBCluster
-	}{
-		// #0
-		{
-			GreptimeDBCluster{
-				Spec: GreptimeDBClusterSpec{
-					Base: &PodTemplateSpec{
-						MainContainer: &MainContainerSpec{
-							Image: "greptime/greptimedb:latest",
-						},
-					},
-					Frontend: &FrontendSpec{
-						ComponentSpec: ComponentSpec{
-							Replicas: proto.Int32(3),
-						},
-					},
-					Meta: &MetaSpec{
-						ComponentSpec: ComponentSpec{
-							Replicas: proto.Int32(3),
-						},
-					},
-					Datanode: &DatanodeSpec{
-						ComponentSpec: ComponentSpec{
-							Replicas: proto.Int32(1),
-						},
-					},
-				},
-			},
-			GreptimeDBCluster{
-				Spec: GreptimeDBClusterSpec{
-					Initializer: &InitializerSpec{Image: defaultInitializer},
-					Base: &PodTemplateSpec{
-						MainContainer: &MainContainerSpec{
-							Image: "greptime/greptimedb:latest",
-							ReadinessProbe: &corev1.Probe{
-								ProbeHandler: corev1.ProbeHandler{
-									HTTPGet: &corev1.HTTPGetAction{
-										Path: "/health",
-										Port: intstr.FromInt(defaultHTTPServicePort),
-									},
-								},
-							},
-						},
-					},
-					Frontend: &FrontendSpec{
-						ComponentSpec: ComponentSpec{
-							Replicas: proto.Int32(3),
-							Template: &PodTemplateSpec{
-								MainContainer: &MainContainerSpec{
-									Image: "greptime/greptimedb:latest",
-									ReadinessProbe: &corev1.Probe{
-										ProbeHandler: corev1.ProbeHandler{
-											HTTPGet: &corev1.HTTPGetAction{
-												Path: "/health",
-												Port: intstr.FromInt(defaultHTTPServicePort),
-											},
-										},
-									},
-								},
-							},
-						},
-						Service: ServiceSpec{
-							Type: corev1.ServiceTypeClusterIP,
-						},
-					},
-					Meta: &MetaSpec{
-						ComponentSpec: ComponentSpec{
-							Replicas: proto.Int32(3),
-							Template: &PodTemplateSpec{
-								MainContainer: &MainContainerSpec{
-									Image: "greptime/greptimedb:latest",
-									ReadinessProbe: &corev1.Probe{
-										ProbeHandler: corev1.ProbeHandler{
-											HTTPGet: &corev1.HTTPGetAction{
-												Path: "/health",
-												Port: intstr.FromInt(defaultHTTPServicePort),
-											},
-										},
-									},
-								},
-							},
-						},
-						ServicePort:          int32(defaultMetaServicePort),
-						EnableRegionFailover: proto.Bool(false),
-					},
-					Datanode: &DatanodeSpec{
-						ComponentSpec: ComponentSpec{
-							Replicas: proto.Int32(1),
-							Template: &PodTemplateSpec{
-								MainContainer: &MainContainerSpec{
-									Image: "greptime/greptimedb:latest",
-									ReadinessProbe: &corev1.Probe{
-										ProbeHandler: corev1.ProbeHandler{
-											HTTPGet: &corev1.HTTPGetAction{
-												Path: "/health",
-												Port: intstr.FromInt(defaultHTTPServicePort),
-											},
-										},
-									},
-								},
-							},
-						},
-						Storage: StorageSpec{
-							Name:                defaultDataNodeStorageName,
-							StorageSize:         defaultDataNodeStorageSize,
-							MountPath:           defaultDataNodeStorageMountPath,
-							StorageRetainPolicy: defaultStorageRetainPolicyType,
-							WalDir:              defaultDataNodeStorageMountPath + "/wal",
-							DataHome:            defaultDataNodeStorageMountPath,
-						},
-					},
-					HTTPServicePort:     int32(defaultHTTPServicePort),
-					GRPCServicePort:     int32(defaultGRPCServicePort),
-					MySQLServicePort:    int32(defaultMySQLServicePort),
-					PostgresServicePort: int32(defaultPostgresServicePort),
-					Version:             "latest",
-				},
-			},
-		},
+func TestClusterSetDefaults(t *testing.T) {
+	const (
+		testDir        = "testdata/greptimedbcluster"
+		inputFileName  = "input.yaml"
+		expectFileName = "expect.yaml"
+	)
 
-		// #1
-		{
-			GreptimeDBCluster{
-				Spec: GreptimeDBClusterSpec{
-					Base: &PodTemplateSpec{
-						MainContainer: &MainContainerSpec{
-							Image: "greptime/greptimedb:latest",
-							Resources: corev1.ResourceRequirements{
-								Requests: map[corev1.ResourceName]resource.Quantity{
-									"cpu":    resource.MustParse("500m"),
-									"memory": resource.MustParse("256Mi"),
-								},
-								Limits: map[corev1.ResourceName]resource.Quantity{
-									"cpu":    resource.MustParse("1000m"),
-									"memory": resource.MustParse("1024Mi"),
-								},
-							},
-						},
-					},
-					Frontend: &FrontendSpec{
-						ComponentSpec: ComponentSpec{
-							Template: &PodTemplateSpec{
-								MainContainer: &MainContainerSpec{
-									Image: "greptime/frontend:latest",
-									Args: []string{
-										"--metasrv-addrs",
-										"meta.default:3002",
-									},
-								},
-							},
-						},
-					},
-					Meta: &MetaSpec{
-						ComponentSpec: ComponentSpec{
-							Template: &PodTemplateSpec{
-								MainContainer: &MainContainerSpec{
-									Image: "greptime/meta:latest",
-									Args: []string{
-										"--store-addr",
-										"etcd.default:2379",
-									},
-								},
-							},
-						},
-						EtcdEndpoints: []string{
-							"etcd.default:2379",
-						},
-					},
-					Datanode: &DatanodeSpec{
-						ComponentSpec: ComponentSpec{
-							Template: &PodTemplateSpec{
-								MainContainer: &MainContainerSpec{
-									Image: "greptime/greptimedb:latest",
-								},
-							},
-						},
-					},
-				},
-			},
-			GreptimeDBCluster{
-				Spec: GreptimeDBClusterSpec{
-					Initializer: &InitializerSpec{Image: defaultInitializer},
-					Base: &PodTemplateSpec{
-						MainContainer: &MainContainerSpec{
-							Image: "greptime/greptimedb:latest",
-							Resources: corev1.ResourceRequirements{
-								Requests: map[corev1.ResourceName]resource.Quantity{
-									"cpu":    resource.MustParse("500m"),
-									"memory": resource.MustParse("256Mi"),
-								},
-								Limits: map[corev1.ResourceName]resource.Quantity{
-									"cpu":    resource.MustParse("1000m"),
-									"memory": resource.MustParse("1024Mi"),
-								},
-							},
-							ReadinessProbe: &corev1.Probe{
-								ProbeHandler: corev1.ProbeHandler{
-									HTTPGet: &corev1.HTTPGetAction{
-										Path: "/health",
-										Port: intstr.FromInt(defaultHTTPServicePort),
-									},
-								},
-							},
-						},
-					},
-					Frontend: &FrontendSpec{
-						ComponentSpec: ComponentSpec{
-							Replicas: proto.Int32(defaultFrontendReplicas),
-							Template: &PodTemplateSpec{
-								MainContainer: &MainContainerSpec{
-									Image: "greptime/frontend:latest",
-									Args: []string{
-										"--metasrv-addrs",
-										"meta.default:3002",
-									},
-									Resources: corev1.ResourceRequirements{
-										Requests: map[corev1.ResourceName]resource.Quantity{
-											"cpu":    resource.MustParse("500m"),
-											"memory": resource.MustParse("256Mi"),
-										},
-										Limits: map[corev1.ResourceName]resource.Quantity{
-											"cpu":    resource.MustParse("1000m"),
-											"memory": resource.MustParse("1024Mi"),
-										},
-									},
-									ReadinessProbe: &corev1.Probe{
-										ProbeHandler: corev1.ProbeHandler{
-											HTTPGet: &corev1.HTTPGetAction{
-												Path: "/health",
-												Port: intstr.FromInt(defaultHTTPServicePort),
-											},
-										},
-									},
-								},
-							},
-						},
-						Service: ServiceSpec{
-							Type: corev1.ServiceTypeClusterIP,
-						},
-					},
-					Meta: &MetaSpec{
-						ComponentSpec: ComponentSpec{
-							Replicas: proto.Int32(defaultMetaReplicas),
-							Template: &PodTemplateSpec{
-								MainContainer: &MainContainerSpec{
-									Image: "greptime/meta:latest",
-									Args: []string{
-										"--store-addr",
-										"etcd.default:2379",
-									},
-									Resources: corev1.ResourceRequirements{
-										Requests: map[corev1.ResourceName]resource.Quantity{
-											"cpu":    resource.MustParse("500m"),
-											"memory": resource.MustParse("256Mi"),
-										},
-										Limits: map[corev1.ResourceName]resource.Quantity{
-											"cpu":    resource.MustParse("1000m"),
-											"memory": resource.MustParse("1024Mi"),
-										},
-									},
-									ReadinessProbe: &corev1.Probe{
-										ProbeHandler: corev1.ProbeHandler{
-											HTTPGet: &corev1.HTTPGetAction{
-												Path: "/health",
-												Port: intstr.FromInt(defaultHTTPServicePort),
-											},
-										},
-									},
-								},
-							},
-						},
-						EtcdEndpoints: []string{
-							"etcd.default:2379",
-						},
-						ServicePort:          int32(defaultMetaServicePort),
-						EnableRegionFailover: proto.Bool(false),
-					},
-					Datanode: &DatanodeSpec{
-						ComponentSpec: ComponentSpec{
-							Replicas: proto.Int32(defaultDatanodeReplicas),
-							Template: &PodTemplateSpec{
-								MainContainer: &MainContainerSpec{
-									Image: "greptime/greptimedb:latest",
-									Resources: corev1.ResourceRequirements{
-										Requests: map[corev1.ResourceName]resource.Quantity{
-											"cpu":    resource.MustParse("500m"),
-											"memory": resource.MustParse("256Mi"),
-										},
-										Limits: map[corev1.ResourceName]resource.Quantity{
-											"cpu":    resource.MustParse("1000m"),
-											"memory": resource.MustParse("1024Mi"),
-										},
-									},
-									ReadinessProbe: &corev1.Probe{
-										ProbeHandler: corev1.ProbeHandler{
-											HTTPGet: &corev1.HTTPGetAction{
-												Path: "/health",
-												Port: intstr.FromInt(defaultHTTPServicePort),
-											},
-										},
-									},
-								},
-							},
-						},
-						Storage: StorageSpec{
-							Name:                defaultDataNodeStorageName,
-							StorageSize:         defaultDataNodeStorageSize,
-							MountPath:           defaultDataNodeStorageMountPath,
-							StorageRetainPolicy: defaultStorageRetainPolicyType,
-							WalDir:              defaultDataNodeStorageMountPath + "/wal",
-							DataHome:            defaultDataNodeStorageMountPath,
-						},
-					},
-
-					HTTPServicePort:     int32(defaultHTTPServicePort),
-					GRPCServicePort:     int32(defaultGRPCServicePort),
-					MySQLServicePort:    int32(defaultMySQLServicePort),
-					PostgresServicePort: int32(defaultPostgresServicePort),
-					Version:             "latest",
-				},
-			},
-		},
-
-		// #2
-		{
-			GreptimeDBCluster{
-				Spec: GreptimeDBClusterSpec{
-					Base: &PodTemplateSpec{
-						MainContainer: &MainContainerSpec{
-							Image: "greptime/greptimedb:latest",
-						},
-					},
-					Datanode: &DatanodeSpec{
-						ComponentSpec: ComponentSpec{
-							Replicas: proto.Int32(0),
-						},
-						Storage: StorageSpec{
-							Name:                "data",
-							StorageClassName:    proto.String("ebs-gp3"),
-							StorageSize:         "20Gi",
-							MountPath:           "/tmp/greptimedb",
-							StorageRetainPolicy: StorageRetainPolicyTypeDelete,
-							WalDir:              "tmp/greptimedb/wal",
-							DataHome:            "/tmp/greptimedb",
-						},
-					},
-					Frontend: &FrontendSpec{
-						ComponentSpec: ComponentSpec{
-							Replicas: proto.Int32(0),
-						},
-					},
-					Meta: &MetaSpec{
-						ComponentSpec: ComponentSpec{
-							Replicas: proto.Int32(0),
-						},
-					},
-				},
-			},
-			GreptimeDBCluster{
-				Spec: GreptimeDBClusterSpec{
-					Initializer: &InitializerSpec{Image: defaultInitializer},
-					Base: &PodTemplateSpec{
-						MainContainer: &MainContainerSpec{
-							Image: "greptime/greptimedb:latest",
-							ReadinessProbe: &corev1.Probe{
-								ProbeHandler: corev1.ProbeHandler{
-									HTTPGet: &corev1.HTTPGetAction{
-										Path: "/health",
-										Port: intstr.FromInt(defaultHTTPServicePort),
-									},
-								},
-							},
-						},
-					},
-					Frontend: &FrontendSpec{
-						ComponentSpec: ComponentSpec{
-							Replicas: proto.Int32(0),
-							Template: &PodTemplateSpec{
-								MainContainer: &MainContainerSpec{
-									Image: "greptime/greptimedb:latest",
-									ReadinessProbe: &corev1.Probe{
-										ProbeHandler: corev1.ProbeHandler{
-											HTTPGet: &corev1.HTTPGetAction{
-												Path: "/health",
-												Port: intstr.FromInt(defaultHTTPServicePort),
-											},
-										},
-									},
-								},
-							},
-						},
-						Service: ServiceSpec{
-							Type: corev1.ServiceTypeClusterIP,
-						},
-					},
-					Meta: &MetaSpec{
-						ComponentSpec: ComponentSpec{
-							Replicas: proto.Int32(0),
-							Template: &PodTemplateSpec{
-								MainContainer: &MainContainerSpec{
-									Image: "greptime/greptimedb:latest",
-									ReadinessProbe: &corev1.Probe{
-										ProbeHandler: corev1.ProbeHandler{
-											HTTPGet: &corev1.HTTPGetAction{
-												Path: "/health",
-												Port: intstr.FromInt(defaultHTTPServicePort),
-											},
-										},
-									},
-								},
-							},
-						},
-						ServicePort:          int32(defaultMetaServicePort),
-						EnableRegionFailover: proto.Bool(false),
-					},
-					Datanode: &DatanodeSpec{
-						ComponentSpec: ComponentSpec{
-							Replicas: proto.Int32(0),
-							Template: &PodTemplateSpec{
-								MainContainer: &MainContainerSpec{
-									Image: "greptime/greptimedb:latest",
-									ReadinessProbe: &corev1.Probe{
-										ProbeHandler: corev1.ProbeHandler{
-											HTTPGet: &corev1.HTTPGetAction{
-												Path: "/health",
-												Port: intstr.FromInt(defaultHTTPServicePort),
-											},
-										},
-									},
-								},
-							},
-						},
-						Storage: StorageSpec{
-							Name:                "data",
-							StorageClassName:    proto.String("ebs-gp3"),
-							StorageSize:         "20Gi",
-							MountPath:           "/tmp/greptimedb",
-							StorageRetainPolicy: StorageRetainPolicyTypeDelete,
-							WalDir:              "tmp/greptimedb/wal",
-							DataHome:            "/tmp/greptimedb",
-						},
-					},
-
-					HTTPServicePort:     int32(defaultHTTPServicePort),
-					GRPCServicePort:     int32(defaultGRPCServicePort),
-					MySQLServicePort:    int32(defaultMySQLServicePort),
-					PostgresServicePort: int32(defaultPostgresServicePort),
-					Version:             "latest",
-				},
-			},
-		},
+	entries, err := os.ReadDir(testDir)
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	for i, tt := range tests {
-		if err := tt.input.SetDefaults(); err != nil {
-			t.Errorf("set default cluster failed: %v", err)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			inputFile := filepath.Join(testDir, entry.Name(), inputFileName)
+			inputData, err := os.ReadFile(inputFile)
+			if err != nil {
+				t.Errorf("failed to read %s: %v", inputFile, err)
+			}
+
+			expectFile := filepath.Join(testDir, entry.Name(), expectFileName)
+			expectData, err := os.ReadFile(expectFile)
+			if err != nil {
+				t.Fatalf("failed to read %s: %v", expectFile, err)
+			}
+
+			var (
+				input  GreptimeDBCluster
+				expect GreptimeDBCluster
+			)
+			if err := yaml.Unmarshal(inputData, &input); err != nil {
+				t.Fatalf("failed to unmarshal %s: %v", inputFile, err)
+			}
+			if err := yaml.Unmarshal(expectData, &expect); err != nil {
+				t.Fatalf("failed to unmarshal %s: %v", expectFile, err)
+			}
+
+			if err := input.SetDefaults(); err != nil {
+				t.Fatalf("failed to set defaults: %v", err)
+			}
+
+			if !reflect.DeepEqual(input, expect) {
+				rawInputData, err := yaml.Marshal(input)
+				if err != nil {
+					t.Fatalf("failed to marshal: %v", err)
+				}
+
+				rawExpectData, err := yaml.Marshal(expect)
+				if err != nil {
+					t.Fatalf("failed to marshal: %v", err)
+				}
+
+				// Use diffmatchpatch to get a human-readable diff.
+				dmp := diffmatchpatch.New()
+				t.Errorf("unexpected result for %s:\n%s", entry.Name(), dmp.DiffPrettyText(dmp.DiffMain(string(rawExpectData), string(rawInputData), false)))
+			}
 		}
-
-		if !reflect.DeepEqual(tt.want, tt.input) {
-			t.Errorf("run test [%d] failed, want %v, got %v", i, tt.want, tt.input)
-		}
-	}
-}
-
-func TestDefaultEnableRegionFailover(t *testing.T) {
-	clusterWithRemoteWAL := GreptimeDBCluster{
-		Spec: GreptimeDBClusterSpec{
-			Base: &PodTemplateSpec{
-				MainContainer: &MainContainerSpec{
-					Image: "greptime/greptimedb:latest",
-				},
-			},
-			Datanode: &DatanodeSpec{
-				ComponentSpec: ComponentSpec{
-					Replicas: proto.Int32(1),
-				},
-			},
-			Frontend: &FrontendSpec{
-				ComponentSpec: ComponentSpec{
-					Replicas: proto.Int32(1),
-				},
-			},
-			Meta: &MetaSpec{
-				ComponentSpec: ComponentSpec{
-					Replicas: proto.Int32(1),
-				},
-			},
-			RemoteWalProvider: &RemoteWalProvider{KafkaRemoteWal: &KafkaRemoteWal{
-				BrokerEndpoints: []string{"kafka.default:9092"},
-			}},
-		},
-	}
-
-	if err := clusterWithRemoteWAL.SetDefaults(); err != nil {
-		t.Errorf("set default cluster failed: %v", err)
-	}
-
-	if *clusterWithRemoteWAL.Spec.Meta.EnableRegionFailover != true {
-		t.Errorf("default EnableRegionFailover should be true")
 	}
 }

--- a/apis/v1alpha1/greptimedbcluster_types.go
+++ b/apis/v1alpha1/greptimedbcluster_types.go
@@ -38,8 +38,13 @@ type ComponentSpec struct {
 type MetaSpec struct {
 	ComponentSpec `json:",inline"`
 
+	// The RPC port of the meta.
 	// +optional
-	ServicePort int32 `json:"servicePort,omitempty"`
+	RPCPort int32 `json:"rpcPort,omitempty"`
+
+	// The HTTP port of the meta.
+	// +optional
+	HTTPPort int32 `json:"httpPort,omitempty"`
 
 	// +optional
 	EtcdEndpoints []string `json:"etcdEndpoints,omitempty"`
@@ -55,8 +60,6 @@ type MetaSpec struct {
 	// The meta will store data with this key prefix.
 	// +optional
 	StoreKeyPrefix string `json:"storeKeyPrefix,omitempty"`
-
-	// More meta settings can be added here...
 }
 
 // FrontendSpec is the specification for frontend component.
@@ -69,21 +72,32 @@ type FrontendSpec struct {
 	// The TLS configurations of the frontend.
 	// +optional
 	TLS *TLSSpec `json:"tls,omitempty"`
-
-	// More frontend settings can be added here...
 }
 
 // DatanodeSpec is the specification for datanode component.
 type DatanodeSpec struct {
 	ComponentSpec `json:",inline"`
 
+	// The RPC port of the datanode.
+	// +optional
+	RPCPort int32 `json:"rpcPort,omitempty"`
+
+	// The HTTP port of the datanode.
+	// +optional
+	HTTPPort int32 `json:"httpPort,omitempty"`
+
+	// Storage is the storage specification for the datanode.
+	// +optional
 	Storage StorageSpec `json:"storage,omitempty"`
-	// More datanode settings can be added here...
 }
 
 // FlownodeSpec is the specification for flownode component.
 type FlownodeSpec struct {
 	ComponentSpec `json:",inline"`
+
+	// The gRPC port of the flownode.
+	// +optional
+	RPCPort int32 `json:"rpcPort,omitempty"`
 }
 
 // InitializerSpec is the init container to set up components configurations before running the container.
@@ -115,16 +129,16 @@ type GreptimeDBClusterSpec struct {
 	Flownode *FlownodeSpec `json:"flownode"`
 
 	// +optional
-	HTTPServicePort int32 `json:"httpServicePort,omitempty"`
+	HTTPPort int32 `json:"httpPort,omitempty"`
 
 	// +optional
-	GRPCServicePort int32 `json:"grpcServicePort,omitempty"`
+	RPCPort int32 `json:"rpcPort,omitempty"`
 
 	// +optional
-	MySQLServicePort int32 `json:"mysqlServicePort,omitempty"`
+	MySQLPort int32 `json:"mysqlPort,omitempty"`
 
 	// +optional
-	PostgresServicePort int32 `json:"postgresServicePort,omitempty"`
+	PostgreSQLPort int32 `json:"postgreSQLPort,omitempty"`
 
 	// +optional
 	EnableInfluxDBProtocol bool `json:"enableInfluxDBProtocol,omitempty"`

--- a/apis/v1alpha1/greptimedbstandalone_types.go
+++ b/apis/v1alpha1/greptimedbstandalone_types.go
@@ -32,16 +32,16 @@ type GreptimeDBStandaloneSpec struct {
 	TLS *TLSSpec `json:"tls,omitempty"`
 
 	// +optional
-	HTTPServicePort int32 `json:"httpServicePort,omitempty"`
+	HTTPServicePort int32 `json:"httpPort,omitempty"`
 
 	// +optional
-	GRPCServicePort int32 `json:"grpcServicePort,omitempty"`
+	RPCPort int32 `json:"rpcPort,omitempty"`
 
 	// +optional
-	MySQLServicePort int32 `json:"mysqlServicePort,omitempty"`
+	MySQLPort int32 `json:"mysqlPort,omitempty"`
 
 	// +optional
-	PostgresServicePort int32 `json:"postgresServicePort,omitempty"`
+	PostgreSQLPort int32 `json:"postgreSQLPort,omitempty"`
 
 	// +optional
 	EnableInfluxDBProtocol bool `json:"enableInfluxDBProtocol,omitempty"`

--- a/apis/v1alpha1/testdata/greptimedbcluster/test00/expect.yaml
+++ b/apis/v1alpha1/testdata/greptimedbcluster/test00/expect.yaml
@@ -1,0 +1,61 @@
+apiVersion: greptime.io/v1alpha1
+kind: GreptimeDBCluster
+metadata:
+  name: test00
+  namespace: default
+spec:
+  version: latest
+  initializer:
+    image: greptime/greptimedb-initializer:latest
+  httpPort: 5000
+  rpcPort: 4001
+  mysqlPort: 4002
+  postgreSQLPort: 4003
+  base:
+    main:
+      image: greptime/greptimedb:latest
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: 4000
+  frontend:
+    replicas: 3
+    service:
+      type: ClusterIP
+    template:
+      main:
+        image: greptime/greptimedb:latest
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 5000
+  meta:
+    enableRegionFailover: false
+    httpPort: 4000
+    rpcPort: 3002
+    replicas: 3
+    template:
+      main:
+        image: greptime/greptimedb:latest
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 4000
+  datanode:
+    httpPort: 4000
+    rpcPort: 4001
+    replicas: 1
+    storage:
+      dataHome: /data/greptimedb
+      mountPath: /data/greptimedb
+      name: datanode
+      storageRetainPolicy: Retain
+      storageSize: 10Gi
+      walDir: /data/greptimedb/wal
+    template:
+      main:
+        image: greptime/greptimedb:latest
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 4000

--- a/apis/v1alpha1/testdata/greptimedbcluster/test00/input.yaml
+++ b/apis/v1alpha1/testdata/greptimedbcluster/test00/input.yaml
@@ -1,0 +1,16 @@
+apiVersion: greptime.io/v1alpha1
+kind: GreptimeDBCluster
+metadata:
+  name: test00
+  namespace: default
+spec:
+  base:
+    main:
+      image: greptime/greptimedb:latest
+  frontend:
+    replicas: 3
+  meta:
+    replicas: 3
+  datanode:
+    replicas: 1
+  httpPort: 5000

--- a/apis/v1alpha1/testdata/greptimedbcluster/test01/expect.yaml
+++ b/apis/v1alpha1/testdata/greptimedbcluster/test01/expect.yaml
@@ -1,0 +1,97 @@
+apiVersion: greptime.io/v1alpha1
+kind: GreptimeDBCluster
+metadata:
+  name: test01
+  namespace: default
+spec:
+  version: latest
+  initializer:
+    image: greptime/greptimedb-initializer:latest
+  httpPort: 4000
+  rpcPort: 4001
+  mysqlPort: 4002
+  postgreSQLPort: 4003
+  base:
+    main:
+      image: greptime/greptimedb:latest
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: 4000
+      resources:
+        requests:
+          cpu: "500m"
+          memory: "256Mi"
+        limits:
+          cpu: "1"
+          memory: "1Gi"
+  frontend:
+    replicas: 1
+    service:
+      type: ClusterIP
+    template:
+      main:
+        image: greptime/greptimedb:latest
+        args:
+          - --metasrv-addrs
+          - meta.default:3002
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "256Mi"
+          limits:
+            cpu: "1"
+            memory: "1Gi"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 4000
+  meta:
+    enableRegionFailover: false
+    etcdEndpoints:
+      - etcd.default:2379
+    httpPort: 4000
+    rpcPort: 3002
+    replicas: 1
+    template:
+      main:
+        image: greptime/greptimedb:latest
+        args:
+          - --store-addr
+          - etcd.default:2379
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "256Mi"
+          limits:
+            cpu: "1"
+            memory: "1Gi"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 4000
+  datanode:
+    httpPort: 4000
+    rpcPort: 4001
+    replicas: 3
+    storage:
+      dataHome: /data/greptimedb
+      mountPath: /data/greptimedb
+      name: datanode
+      storageRetainPolicy: Retain
+      storageSize: 10Gi
+      walDir: /data/greptimedb/wal
+    template:
+      main:
+        image: greptime/greptimedb:latest
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "256Mi"
+          limits:
+            cpu: "1"
+            memory: "1Gi"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 4000

--- a/apis/v1alpha1/testdata/greptimedbcluster/test01/input.yaml
+++ b/apis/v1alpha1/testdata/greptimedbcluster/test01/input.yaml
@@ -1,0 +1,36 @@
+apiVersion: greptime.io/v1alpha1
+kind: GreptimeDBCluster
+metadata:
+  name: test01
+  namespace: default
+spec:
+  base:
+    main:
+      image: greptime/greptimedb:latest
+      resources:
+        requests:
+          cpu: "500m"
+          memory: "256Mi"
+        limits:
+          cpu: "1"
+          memory: "1Gi"
+  frontend:
+    template:
+      main:
+        image: greptime/greptimedb:latest
+        args:
+          - --metasrv-addrs
+          - meta.default:3002
+  meta:
+    etcdEndpoints:
+      - etcd.default:2379
+    template:
+      main:
+        image: greptime/greptimedb:latest
+        args:
+          - --store-addr
+          - etcd.default:2379
+  datanode:
+    template:
+      main:
+        image: greptime/greptimedb:latest

--- a/apis/v1alpha1/testdata/greptimedbcluster/test02/expect.yaml
+++ b/apis/v1alpha1/testdata/greptimedbcluster/test02/expect.yaml
@@ -1,0 +1,66 @@
+apiVersion: greptime.io/v1alpha1
+kind: GreptimeDBCluster
+metadata:
+  name: test02
+  namespace: default
+spec:
+  version: latest
+  initializer:
+    image: greptime/greptimedb-initializer:latest
+  httpPort: 4000
+  rpcPort: 4001
+  mysqlPort: 4002
+  postgreSQLPort: 4003
+  remoteWal:
+    kafka:
+      brokerEndpoints:
+        - kafka.default:9092
+  base:
+    main:
+      image: greptime/greptimedb:latest
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: 4000
+  frontend:
+    replicas: 1
+    service:
+      type: ClusterIP
+    template:
+      main:
+        image: greptime/greptimedb:latest
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 4000
+  meta:
+    # Should be true if remoteWal.kafka is set.
+    enableRegionFailover: true
+    httpPort: 4000
+    rpcPort: 3002
+    replicas: 1
+    template:
+      main:
+        image: greptime/greptimedb:latest
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 4000
+  datanode:
+    httpPort: 4000
+    rpcPort: 4001
+    replicas: 1
+    storage:
+      dataHome: /data/greptimedb
+      mountPath: /data/greptimedb
+      name: datanode
+      storageRetainPolicy: Retain
+      storageSize: 10Gi
+      walDir: /data/greptimedb/wal
+    template:
+      main:
+        image: greptime/greptimedb:latest
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 4000

--- a/apis/v1alpha1/testdata/greptimedbcluster/test02/input.yaml
+++ b/apis/v1alpha1/testdata/greptimedbcluster/test02/input.yaml
@@ -1,0 +1,19 @@
+apiVersion: greptime.io/v1alpha1
+kind: GreptimeDBCluster
+metadata:
+  name: test02
+  namespace: default
+spec:
+  base:
+    main:
+      image: greptime/greptimedb:latest
+  frontend:
+    replicas: 1
+  meta:
+    replicas: 1
+  datanode:
+    replicas: 1
+  remoteWal:
+    kafka:
+      brokerEndpoints:
+        - kafka.default:9092

--- a/config/crd/resources/greptime.io_greptimedbclusters.yaml
+++ b/config/crd/resources/greptime.io_greptimedbclusters.yaml
@@ -2692,9 +2692,15 @@ spec:
                 properties:
                   config:
                     type: string
+                  httpPort:
+                    format: int32
+                    type: integer
                   replicas:
                     format: int32
                     minimum: 0
+                    type: integer
+                  rpcPort:
+                    format: int32
                     type: integer
                   storage:
                     properties:
@@ -5364,6 +5370,9 @@ spec:
                   replicas:
                     format: int32
                     minimum: 0
+                    type: integer
+                  rpcPort:
+                    format: int32
                     type: integer
                   template:
                     properties:
@@ -10669,10 +10678,7 @@ spec:
                         type: string
                     type: object
                 type: object
-              grpcServicePort:
-                format: int32
-                type: integer
-              httpServicePort:
+              httpPort:
                 format: int32
                 type: integer
               initializer:
@@ -10692,11 +10698,14 @@ spec:
                     items:
                       type: string
                     type: array
+                  httpPort:
+                    format: int32
+                    type: integer
                   replicas:
                     format: int32
                     minimum: 0
                     type: integer
-                  servicePort:
+                  rpcPort:
                     format: int32
                     type: integer
                   storeKeyPrefix:
@@ -13339,7 +13348,7 @@ spec:
                         type: array
                     type: object
                 type: object
-              mysqlServicePort:
+              mysqlPort:
                 format: int32
                 type: integer
               objectStorage:
@@ -13388,7 +13397,7 @@ spec:
                         type: string
                     type: object
                 type: object
-              postgresServicePort:
+              postgreSQLPort:
                 format: int32
                 type: integer
               prometheusMonitor:
@@ -13412,6 +13421,9 @@ spec:
                         type: array
                     type: object
                 type: object
+              rpcPort:
+                format: int32
+                type: integer
               version:
                 type: string
             type: object

--- a/config/crd/resources/greptime.io_greptimedbstandalones.yaml
+++ b/config/crd/resources/greptime.io_greptimedbstandalones.yaml
@@ -2680,10 +2680,7 @@ spec:
                 type: string
               enableInfluxDBProtocol:
                 type: boolean
-              grpcServicePort:
-                format: int32
-                type: integer
-              httpServicePort:
+              httpPort:
                 format: int32
                 type: integer
               initializer:
@@ -2712,7 +2709,7 @@ spec:
                   walDir:
                     type: string
                 type: object
-              mysqlServicePort:
+              mysqlPort:
                 format: int32
                 type: integer
               objectStorage:
@@ -2761,7 +2758,7 @@ spec:
                         type: string
                     type: object
                 type: object
-              postgresServicePort:
+              postgreSQLPort:
                 format: int32
                 type: integer
               prometheusMonitor:
@@ -2785,6 +2782,9 @@ spec:
                         type: array
                     type: object
                 type: object
+              rpcPort:
+                format: int32
+                type: integer
               service:
                 properties:
                   annotations:

--- a/controllers/greptimedbcluster/deployers/flownode.go
+++ b/controllers/greptimedbcluster/deployers/flownode.go
@@ -237,7 +237,7 @@ func (b *flownodeBuilder) BuildPodMonitor() deployer.Builder {
 func (b *flownodeBuilder) generateMainContainerArgs() []string {
 	return []string{
 		"flownode", "start",
-		"--metasrv-addrs", fmt.Sprintf("%s.%s:%d", common.ResourceName(b.Cluster.Name, v1alpha1.MetaComponentKind), b.Cluster.Namespace, b.Cluster.Spec.Meta.ServicePort),
+		"--metasrv-addrs", fmt.Sprintf("%s.%s:%d", common.ResourceName(b.Cluster.Name, v1alpha1.MetaComponentKind), b.Cluster.Namespace, b.Cluster.Spec.Meta.RPCPort),
 		"--config-file", path.Join(constant.GreptimeDBConfigDir, constant.GreptimeDBConfigFileName),
 	}
 }
@@ -272,7 +272,7 @@ func (b *flownodeBuilder) generateInitializer() *corev1.Container {
 		Args: []string{
 			"--config-path", path.Join(constant.GreptimeDBConfigDir, constant.GreptimeDBConfigFileName),
 			"--init-config-path", path.Join(constant.GreptimeDBInitConfigDir, constant.GreptimeDBConfigFileName),
-			"--rpc-port", fmt.Sprintf("%d", b.Cluster.Spec.GRPCServicePort),
+			"--rpc-port", fmt.Sprintf("%d", b.Cluster.Spec.Flownode.RPCPort),
 			"--service-name", common.ResourceName(b.Cluster.Name, b.ComponentKind),
 			"--namespace", b.Cluster.Namespace,
 			"--component-kind", string(b.ComponentKind),
@@ -348,9 +348,9 @@ func (b *flownodeBuilder) addInitConfigDirVolume(template *corev1.PodTemplateSpe
 func (b *flownodeBuilder) servicePorts() []corev1.ServicePort {
 	return []corev1.ServicePort{
 		{
-			Name:     "grpc",
+			Name:     "rpc",
 			Protocol: corev1.ProtocolTCP,
-			Port:     b.Cluster.Spec.GRPCServicePort,
+			Port:     b.Cluster.Spec.Flownode.RPCPort,
 		},
 	}
 }
@@ -360,7 +360,7 @@ func (b *flownodeBuilder) containerPorts() []corev1.ContainerPort {
 		{
 			Name:          "grpc",
 			Protocol:      corev1.ProtocolTCP,
-			ContainerPort: b.Cluster.Spec.GRPCServicePort,
+			ContainerPort: b.Cluster.Spec.Flownode.RPCPort,
 		},
 	}
 }

--- a/controllers/greptimedbcluster/deployers/frontend.go
+++ b/controllers/greptimedbcluster/deployers/frontend.go
@@ -242,12 +242,12 @@ func (b *frontendBuilder) Generate() ([]client.Object, error) {
 func (b *frontendBuilder) generateMainContainerArgs() []string {
 	var args = []string{
 		"frontend", "start",
-		"--rpc-addr", fmt.Sprintf("0.0.0.0:%d", b.Cluster.Spec.GRPCServicePort),
+		"--rpc-addr", fmt.Sprintf("0.0.0.0:%d", b.Cluster.Spec.RPCPort),
 		"--metasrv-addrs", fmt.Sprintf("%s.%s:%d", common.ResourceName(b.Cluster.Name, v1alpha1.MetaComponentKind),
-			b.Cluster.Namespace, b.Cluster.Spec.Meta.ServicePort),
-		"--http-addr", fmt.Sprintf("0.0.0.0:%d", b.Cluster.Spec.HTTPServicePort),
-		"--mysql-addr", fmt.Sprintf("0.0.0.0:%d", b.Cluster.Spec.MySQLServicePort),
-		"--postgres-addr", fmt.Sprintf("0.0.0.0:%d", b.Cluster.Spec.PostgresServicePort),
+			b.Cluster.Namespace, b.Cluster.Spec.Meta.RPCPort),
+		"--http-addr", fmt.Sprintf("0.0.0.0:%d", b.Cluster.Spec.HTTPPort),
+		"--mysql-addr", fmt.Sprintf("0.0.0.0:%d", b.Cluster.Spec.MySQLPort),
+		"--postgres-addr", fmt.Sprintf("0.0.0.0:%d", b.Cluster.Spec.PostgreSQLPort),
 		"--config-file", path.Join(constant.GreptimeDBConfigDir, constant.GreptimeDBConfigFileName),
 	}
 
@@ -308,24 +308,24 @@ func (b *frontendBuilder) mountTLSSecret(template *corev1.PodTemplateSpec) {
 func (b *frontendBuilder) servicePorts() []corev1.ServicePort {
 	return []corev1.ServicePort{
 		{
-			Name:     "grpc",
+			Name:     "rpc",
 			Protocol: corev1.ProtocolTCP,
-			Port:     b.Cluster.Spec.GRPCServicePort,
+			Port:     b.Cluster.Spec.RPCPort,
 		},
 		{
 			Name:     "http",
 			Protocol: corev1.ProtocolTCP,
-			Port:     b.Cluster.Spec.HTTPServicePort,
+			Port:     b.Cluster.Spec.HTTPPort,
 		},
 		{
 			Name:     "mysql",
 			Protocol: corev1.ProtocolTCP,
-			Port:     b.Cluster.Spec.MySQLServicePort,
+			Port:     b.Cluster.Spec.MySQLPort,
 		},
 		{
-			Name:     "postgres",
+			Name:     "pg",
 			Protocol: corev1.ProtocolTCP,
-			Port:     b.Cluster.Spec.PostgresServicePort,
+			Port:     b.Cluster.Spec.PostgreSQLPort,
 		},
 	}
 }
@@ -333,24 +333,24 @@ func (b *frontendBuilder) servicePorts() []corev1.ServicePort {
 func (b *frontendBuilder) containerPorts() []corev1.ContainerPort {
 	return []corev1.ContainerPort{
 		{
-			Name:          "grpc",
+			Name:          "rpc",
 			Protocol:      corev1.ProtocolTCP,
-			ContainerPort: b.Cluster.Spec.GRPCServicePort,
+			ContainerPort: b.Cluster.Spec.RPCPort,
 		},
 		{
 			Name:          "http",
 			Protocol:      corev1.ProtocolTCP,
-			ContainerPort: b.Cluster.Spec.HTTPServicePort,
+			ContainerPort: b.Cluster.Spec.HTTPPort,
 		},
 		{
 			Name:          "mysql",
 			Protocol:      corev1.ProtocolTCP,
-			ContainerPort: b.Cluster.Spec.MySQLServicePort,
+			ContainerPort: b.Cluster.Spec.MySQLPort,
 		},
 		{
-			Name:          "postgres",
+			Name:          "pg",
 			Protocol:      corev1.ProtocolTCP,
-			ContainerPort: b.Cluster.Spec.PostgresServicePort,
+			ContainerPort: b.Cluster.Spec.PostgreSQLPort,
 		},
 	}
 }

--- a/controllers/greptimedbcluster/deployers/meta.go
+++ b/controllers/greptimedbcluster/deployers/meta.go
@@ -335,10 +335,9 @@ func (b *metaBuilder) generatePodTemplateSpec() *corev1.PodTemplateSpec {
 func (b *metaBuilder) generateMainContainerArgs() []string {
 	return []string{
 		"metasrv", "start",
-		"--bind-addr", fmt.Sprintf("0.0.0.0:%d", b.Cluster.Spec.Meta.ServicePort),
-		// TODO(zyy17): Should we add the new field of the CRD for meta http port?
-		"--http-addr", fmt.Sprintf("0.0.0.0:%d", b.Cluster.Spec.HTTPServicePort),
-		"--server-addr", fmt.Sprintf("$(%s):%d", deployer.EnvPodIP, b.Cluster.Spec.Meta.ServicePort),
+		"--bind-addr", fmt.Sprintf("0.0.0.0:%d", b.Cluster.Spec.Meta.RPCPort),
+		"--http-addr", fmt.Sprintf("0.0.0.0:%d", b.Cluster.Spec.Meta.HTTPPort),
+		"--server-addr", fmt.Sprintf("$(%s):%d", deployer.EnvPodIP, b.Cluster.Spec.Meta.RPCPort),
 		"--store-addr", b.Cluster.Spec.Meta.EtcdEndpoints[0],
 		"--config-file", path.Join(constant.GreptimeDBConfigDir, constant.GreptimeDBConfigFileName),
 	}
@@ -347,14 +346,14 @@ func (b *metaBuilder) generateMainContainerArgs() []string {
 func (b *metaBuilder) servicePorts() []corev1.ServicePort {
 	return []corev1.ServicePort{
 		{
-			Name:     "grpc",
+			Name:     "rpc",
 			Protocol: corev1.ProtocolTCP,
-			Port:     b.Cluster.Spec.Meta.ServicePort,
+			Port:     b.Cluster.Spec.Meta.RPCPort,
 		},
 		{
 			Name:     "http",
 			Protocol: corev1.ProtocolTCP,
-			Port:     b.Cluster.Spec.HTTPServicePort,
+			Port:     b.Cluster.Spec.Meta.HTTPPort,
 		},
 	}
 }
@@ -362,14 +361,14 @@ func (b *metaBuilder) servicePorts() []corev1.ServicePort {
 func (b *metaBuilder) containerPorts() []corev1.ContainerPort {
 	return []corev1.ContainerPort{
 		{
-			Name:          "grpc",
+			Name:          "rpc",
 			Protocol:      corev1.ProtocolTCP,
-			ContainerPort: b.Cluster.Spec.Meta.ServicePort,
+			ContainerPort: b.Cluster.Spec.Meta.RPCPort,
 		},
 		{
 			Name:          "http",
 			Protocol:      corev1.ProtocolTCP,
-			ContainerPort: b.Cluster.Spec.HTTPServicePort,
+			ContainerPort: b.Cluster.Spec.Meta.HTTPPort,
 		},
 	}
 }

--- a/controllers/greptimedbstandalone/deployer.go
+++ b/controllers/greptimedbstandalone/deployer.go
@@ -352,7 +352,7 @@ func (s *standaloneBuilder) servicePorts() []corev1.ServicePort {
 		{
 			Name:     "grpc",
 			Protocol: corev1.ProtocolTCP,
-			Port:     s.standalone.Spec.GRPCServicePort,
+			Port:     s.standalone.Spec.RPCPort,
 		},
 		{
 			Name:     "http",
@@ -362,12 +362,12 @@ func (s *standaloneBuilder) servicePorts() []corev1.ServicePort {
 		{
 			Name:     "mysql",
 			Protocol: corev1.ProtocolTCP,
-			Port:     s.standalone.Spec.MySQLServicePort,
+			Port:     s.standalone.Spec.MySQLPort,
 		},
 		{
 			Name:     "postgres",
 			Protocol: corev1.ProtocolTCP,
-			Port:     s.standalone.Spec.PostgresServicePort,
+			Port:     s.standalone.Spec.PostgreSQLPort,
 		},
 	}
 }
@@ -377,7 +377,7 @@ func (s *standaloneBuilder) containerPorts() []corev1.ContainerPort {
 		{
 			Name:          "grpc",
 			Protocol:      corev1.ProtocolTCP,
-			ContainerPort: s.standalone.Spec.GRPCServicePort,
+			ContainerPort: s.standalone.Spec.RPCPort,
 		},
 		{
 			Name:          "http",
@@ -387,12 +387,12 @@ func (s *standaloneBuilder) containerPorts() []corev1.ContainerPort {
 		{
 			Name:          "mysql",
 			Protocol:      corev1.ProtocolTCP,
-			ContainerPort: s.standalone.Spec.MySQLServicePort,
+			ContainerPort: s.standalone.Spec.MySQLPort,
 		},
 		{
 			Name:          "postgres",
 			Protocol:      corev1.ProtocolTCP,
-			ContainerPort: s.standalone.Spec.PostgresServicePort,
+			ContainerPort: s.standalone.Spec.PostgreSQLPort,
 		},
 	}
 }
@@ -401,10 +401,10 @@ func (s *standaloneBuilder) generateMainContainerArgs() []string {
 	var args = []string{
 		"standalone", "start",
 		"--data-home", "/data",
-		"--rpc-addr", fmt.Sprintf("0.0.0.0:%d", s.standalone.Spec.GRPCServicePort),
-		"--mysql-addr", fmt.Sprintf("0.0.0.0:%d", s.standalone.Spec.MySQLServicePort),
+		"--rpc-addr", fmt.Sprintf("0.0.0.0:%d", s.standalone.Spec.RPCPort),
+		"--mysql-addr", fmt.Sprintf("0.0.0.0:%d", s.standalone.Spec.MySQLPort),
 		"--http-addr", fmt.Sprintf("0.0.0.0:%d", s.standalone.Spec.HTTPServicePort),
-		"--postgres-addr", fmt.Sprintf("0.0.0.0:%d", s.standalone.Spec.PostgresServicePort),
+		"--postgres-addr", fmt.Sprintf("0.0.0.0:%d", s.standalone.Spec.PostgreSQLPort),
 		"--config-file", path.Join(constant.GreptimeDBConfigDir, constant.GreptimeDBConfigFileName),
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,13 @@ module github.com/GreptimeTeam/greptimedb-operator
 go 1.18
 
 require (
+	dario.cat/mergo v1.0.1
 	github.com/go-sql-driver/mysql v1.6.0
-	github.com/imdario/mergo v0.3.13
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.20.1
 	github.com/pelletier/go-toml v1.9.5
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.52.0
+	github.com/sergi/go-diff v1.3.1
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
 	go.etcd.io/etcd/client/v3 v3.5.4
@@ -20,6 +21,7 @@ require (
 	k8s.io/client-go v0.24.0
 	k8s.io/klog/v2 v2.60.1
 	sigs.k8s.io/controller-runtime v0.12.1
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -45,6 +47,7 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
+	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -81,5 +84,4 @@ require (
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
+dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
+dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
@@ -424,6 +426,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
+github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/manifests/greptimedb-operator-crd.yaml
+++ b/manifests/greptimedb-operator-crd.yaml
@@ -2691,9 +2691,15 @@ spec:
                 properties:
                   config:
                     type: string
+                  httpPort:
+                    format: int32
+                    type: integer
                   replicas:
                     format: int32
                     minimum: 0
+                    type: integer
+                  rpcPort:
+                    format: int32
                     type: integer
                   storage:
                     properties:
@@ -5363,6 +5369,9 @@ spec:
                   replicas:
                     format: int32
                     minimum: 0
+                    type: integer
+                  rpcPort:
+                    format: int32
                     type: integer
                   template:
                     properties:
@@ -10668,10 +10677,7 @@ spec:
                         type: string
                     type: object
                 type: object
-              grpcServicePort:
-                format: int32
-                type: integer
-              httpServicePort:
+              httpPort:
                 format: int32
                 type: integer
               initializer:
@@ -10691,11 +10697,14 @@ spec:
                     items:
                       type: string
                     type: array
+                  httpPort:
+                    format: int32
+                    type: integer
                   replicas:
                     format: int32
                     minimum: 0
                     type: integer
-                  servicePort:
+                  rpcPort:
                     format: int32
                     type: integer
                   storeKeyPrefix:
@@ -13338,7 +13347,7 @@ spec:
                         type: array
                     type: object
                 type: object
-              mysqlServicePort:
+              mysqlPort:
                 format: int32
                 type: integer
               objectStorage:
@@ -13387,7 +13396,7 @@ spec:
                         type: string
                     type: object
                 type: object
-              postgresServicePort:
+              postgreSQLPort:
                 format: int32
                 type: integer
               prometheusMonitor:
@@ -13411,6 +13420,9 @@ spec:
                         type: array
                     type: object
                 type: object
+              rpcPort:
+                format: int32
+                type: integer
               version:
                 type: string
             type: object
@@ -16185,10 +16197,7 @@ spec:
                 type: string
               enableInfluxDBProtocol:
                 type: boolean
-              grpcServicePort:
-                format: int32
-                type: integer
-              httpServicePort:
+              httpPort:
                 format: int32
                 type: integer
               initializer:
@@ -16217,7 +16226,7 @@ spec:
                   walDir:
                     type: string
                 type: object
-              mysqlServicePort:
+              mysqlPort:
                 format: int32
                 type: integer
               objectStorage:
@@ -16266,7 +16275,7 @@ spec:
                         type: string
                     type: object
                 type: object
-              postgresServicePort:
+              postgreSQLPort:
                 format: int32
                 type: integer
               prometheusMonitor:
@@ -16290,6 +16299,9 @@ spec:
                         type: array
                     type: object
                 type: object
+              rpcPort:
+                format: int32
+                type: integer
               service:
                 properties:
                   annotations:

--- a/manifests/greptimedb-operator-deployment.yaml
+++ b/manifests/greptimedb-operator-deployment.yaml
@@ -2698,9 +2698,15 @@ spec:
                 properties:
                   config:
                     type: string
+                  httpPort:
+                    format: int32
+                    type: integer
                   replicas:
                     format: int32
                     minimum: 0
+                    type: integer
+                  rpcPort:
+                    format: int32
                     type: integer
                   storage:
                     properties:
@@ -5370,6 +5376,9 @@ spec:
                   replicas:
                     format: int32
                     minimum: 0
+                    type: integer
+                  rpcPort:
+                    format: int32
                     type: integer
                   template:
                     properties:
@@ -10675,10 +10684,7 @@ spec:
                         type: string
                     type: object
                 type: object
-              grpcServicePort:
-                format: int32
-                type: integer
-              httpServicePort:
+              httpPort:
                 format: int32
                 type: integer
               initializer:
@@ -10698,11 +10704,14 @@ spec:
                     items:
                       type: string
                     type: array
+                  httpPort:
+                    format: int32
+                    type: integer
                   replicas:
                     format: int32
                     minimum: 0
                     type: integer
-                  servicePort:
+                  rpcPort:
                     format: int32
                     type: integer
                   storeKeyPrefix:
@@ -13345,7 +13354,7 @@ spec:
                         type: array
                     type: object
                 type: object
-              mysqlServicePort:
+              mysqlPort:
                 format: int32
                 type: integer
               objectStorage:
@@ -13394,7 +13403,7 @@ spec:
                         type: string
                     type: object
                 type: object
-              postgresServicePort:
+              postgreSQLPort:
                 format: int32
                 type: integer
               prometheusMonitor:
@@ -13418,6 +13427,9 @@ spec:
                         type: array
                     type: object
                 type: object
+              rpcPort:
+                format: int32
+                type: integer
               version:
                 type: string
             type: object
@@ -16192,10 +16204,7 @@ spec:
                 type: string
               enableInfluxDBProtocol:
                 type: boolean
-              grpcServicePort:
-                format: int32
-                type: integer
-              httpServicePort:
+              httpPort:
                 format: int32
                 type: integer
               initializer:
@@ -16224,7 +16233,7 @@ spec:
                   walDir:
                     type: string
                 type: object
-              mysqlServicePort:
+              mysqlPort:
                 format: int32
                 type: integer
               objectStorage:
@@ -16273,7 +16282,7 @@ spec:
                         type: string
                     type: object
                 type: object
-              postgresServicePort:
+              postgreSQLPort:
                 format: int32
                 type: integer
               prometheusMonitor:
@@ -16297,6 +16306,9 @@ spec:
                         type: array
                     type: object
                 type: object
+              rpcPort:
+                format: int32
+                type: integer
               service:
                 properties:
                   annotations:

--- a/tests/e2e/greptimedbcluster_test.go
+++ b/tests/e2e/greptimedbcluster_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Test GreptimeDBCluster", func() {
 		}, utils.DefaultTimeout, time.Second).ShouldNot(HaveOccurred())
 
 		By("Execute distributed SQL queries")
-		frontendAddr, err := utils.PortForward(ctx, testCluster.Namespace, common.ResourceName(testCluster.Name, greptimev1alpha1.FrontendComponentKind), int(testCluster.Spec.MySQLServicePort))
+		frontendAddr, err := utils.PortForward(ctx, testCluster.Namespace, common.ResourceName(testCluster.Name, greptimev1alpha1.FrontendComponentKind), int(testCluster.Spec.MySQLPort))
 		Expect(err).NotTo(HaveOccurred(), "failed to port forward frontend service")
 		Eventually(func() error {
 			conn, err := net.Dial("tcp", frontendAddr)
@@ -123,7 +123,7 @@ var _ = Describe("Test GreptimeDBCluster", func() {
 		}, utils.DefaultTimeout, time.Second).ShouldNot(HaveOccurred())
 
 		By("Execute distributed SQL queries")
-		frontendAddr, err := utils.PortForward(ctx, testCluster.Namespace, common.ResourceName(testCluster.Name, greptimev1alpha1.FrontendComponentKind), int(testCluster.Spec.MySQLServicePort))
+		frontendAddr, err := utils.PortForward(ctx, testCluster.Namespace, common.ResourceName(testCluster.Name, greptimev1alpha1.FrontendComponentKind), int(testCluster.Spec.MySQLPort))
 		Expect(err).NotTo(HaveOccurred(), "failed to port forward frontend service")
 		Eventually(func() error {
 			conn, err := net.Dial("tcp", frontendAddr)
@@ -183,7 +183,7 @@ var _ = Describe("Test GreptimeDBCluster", func() {
 		}, utils.DefaultTimeout, time.Second).ShouldNot(HaveOccurred())
 
 		By("Execute distributed SQL queries")
-		frontendAddr, err := utils.PortForward(ctx, testCluster.Namespace, common.ResourceName(testCluster.Name, greptimev1alpha1.FrontendComponentKind), int(testCluster.Spec.MySQLServicePort))
+		frontendAddr, err := utils.PortForward(ctx, testCluster.Namespace, common.ResourceName(testCluster.Name, greptimev1alpha1.FrontendComponentKind), int(testCluster.Spec.MySQLPort))
 		Expect(err).NotTo(HaveOccurred(), "failed to port forward frontend service")
 		Eventually(func() error {
 			conn, err := net.Dial("tcp", frontendAddr)

--- a/tests/e2e/greptimedbstandalone_test.go
+++ b/tests/e2e/greptimedbstandalone_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Test GreptimeDBStandalone", func() {
 		}, utils.DefaultTimeout, time.Second).ShouldNot(HaveOccurred())
 
 		By("Run SQL test")
-		frontendAddr, err := utils.PortForward(ctx, testStandalone.Namespace, common.ResourceName(testStandalone.Name, greptimev1alpha1.StandaloneKind), int(testStandalone.Spec.MySQLServicePort))
+		frontendAddr, err := utils.PortForward(ctx, testStandalone.Namespace, common.ResourceName(testStandalone.Name, greptimev1alpha1.StandaloneKind), int(testStandalone.Spec.MySQLPort))
 		Expect(err).NotTo(HaveOccurred(), "failed to port forward frontend service")
 		Eventually(func() error {
 			conn, err := net.Dial("tcp", frontendAddr)

--- a/tests/e2e/testdata/basic-cluster-with-flownode/cluster.yaml
+++ b/tests/e2e/testdata/basic-cluster-with-flownode/cluster.yaml
@@ -33,4 +33,4 @@ spec:
     replicas: 3
   flownode:
     replicas: 2
-  mysqlServicePort: 4002
+  mysqlPort: 4002

--- a/tests/e2e/testdata/basic-cluster/cluster.yaml
+++ b/tests/e2e/testdata/basic-cluster/cluster.yaml
@@ -31,4 +31,4 @@ spec:
       - etcd.etcd:2379
   datanode:
     replicas: 3
-  mysqlServicePort: 4002
+  mysqlPort: 4002

--- a/tests/e2e/testdata/basic-standalone/standalone.yaml
+++ b/tests/e2e/testdata/basic-standalone/standalone.yaml
@@ -21,4 +21,4 @@ spec:
   base:
     main:
       image: localhost:5001/greptime/greptimedb:latest
-  mysqlServicePort: 4002
+  mysqlPort: 4002

--- a/tests/e2e/testdata/cluster-with-remote-wal/cluster.yaml
+++ b/tests/e2e/testdata/cluster-with-remote-wal/cluster.yaml
@@ -35,4 +35,4 @@ spec:
     kafka:
       brokerEndpoints:
         - kafka-wal-kafka-bootstrap.kafka:9092
-  mysqlServicePort: 4002
+  mysqlPort: 4002


### PR DESCRIPTION
## What's changed

1. Refactor `SetDefaults()` of GreptimeDBCluster to fix probe port setting issue

   **Fix** The bug with the probe's port is always `4000` even the `httpSericePort` is not `4000`;

2. Use livenessProbe instead of readinessProbe

   The `/health` in GreptimeDB is more like a liveness probe.

3. Refine the naming of `*port` filed in GreptimeDBCluster and GreptimeDBStandalone;

4. Refine the unit test structure of `defaulting_test.go`;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Introduced new configuration options for service ports (HTTP, RPC, MySQL, PostgreSQL) in GreptimeDBCluster and GreptimeDBStandalone resources.
	- Added a default health endpoint for service health checks.

- **Bug Fixes**
	- Updated test cases to use the new port naming conventions, ensuring proper connectivity in testing scenarios.

- **Documentation**
	- Enhanced YAML configuration files for clarity and consistency in naming conventions.

- **Chores**
	- Added new dependencies for text diffing and YAML processing to improve functionality and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->