### PR TITLE
refactor: set default values back to the original resource

### DIFF
--- a/apis/v1alpha1/defaulting.go
+++ b/apis/v1alpha1/defaulting.go
@@ -39,7 +39,7 @@ var (
 	// The default replicas for frontend/meta/datanode.
 	defaultFrontendReplicas int32 = 1
 	defaultMetaReplicas     int32 = 1
-	defaultDatanodeReplicas int32 = 3
+	defaultDatanodeReplicas int32 = 1
 	defaultFlownodeReplicas int32 = 1
 
 	// The default storage settings for datanode.

--- a/apis/v1alpha1/testdata/greptimedbcluster/test01/expect.yaml
+++ b/apis/v1alpha1/testdata/greptimedbcluster/test01/expect.yaml
@@ -73,7 +73,7 @@ spec:
   datanode:
     httpPort: 4000
     rpcPort: 4001
-    replicas: 3
+    replicas: 1
     storage:
       dataHome: /data/greptimedb
       mountPath: /data/greptimedb

--- a/tests/e2e/testdata/resources/cluster/basic/cluster.yaml
+++ b/tests/e2e/testdata/resources/cluster/basic/cluster.yaml
@@ -35,4 +35,3 @@ spec:
   rpcPort: 4001
   mysqlPort: 4002
   postgreSQLPort: 4003
-

--- a/tests/e2e/testdata/sql/cluster/flow_basic.sql
+++ b/tests/e2e/testdata/sql/cluster/flow_basic.sql
@@ -1,100 +1,62 @@
-CREATE TABLE numbers_input_basic (
-    number INT,
-    ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY(number),
-    TIME INDEX(ts)
+-- FIXME(zyy17): The test case will be replaced by the real sqlness test case.
+
+CREATE TABLE `ngx_access_log` (
+  `client` STRING NULL,
+  `ua_platform` STRING NULL,
+  `referer` STRING NULL,
+  `method` STRING NULL,
+  `endpoint` STRING NULL,
+  `trace_id` STRING NULL FULLTEXT,
+  `protocol` STRING NULL,
+  `status` SMALLINT UNSIGNED NULL,
+  `size` DOUBLE NULL,
+  `agent` STRING NULL,
+  `access_time` TIMESTAMP(3) NOT NULL,
+    TIME INDEX (`access_time`)
+    )
+WITH(
+    append_mode = 'true'
 );
 
-CREATE FLOW test_numbers_basic 
-SINK TO out_num_cnt_basic
-AS 
-SELECT sum(number) FROM numbers_input_basic GROUP BY tumble(ts, '1 second', '2021-07-01 00:00:00');
+CREATE TABLE `ngx_statistics` (
+  `status` SMALLINT UNSIGNED NULL,
+  `total_logs` BIGINT NULL,
+  `min_size` DOUBLE NULL,
+  `max_size` DOUBLE NULL,
+  `avg_size` DOUBLE NULL,
+  `high_size_count` DOUBLE NULL,
+  `time_window` TIMESTAMP time index,
+  `update_at` TIMESTAMP NULL,
+   PRIMARY KEY (`status`));
 
--- TODO(discord9): confirm if it's necessary to flush flow here?
--- because flush_flow result is at most 1
-select flush_flow('test_numbers_basic')<=1;
-
--- SQLNESS ARG restart=true
-INSERT INTO numbers_input_basic 
-VALUES
-    (20, "2021-07-01 00:00:00.200"),
-    (22, "2021-07-01 00:00:00.600");
-
-select flush_flow('test_numbers_basic')<=1;
-
-SELECT col_0, window_start, window_end FROM out_num_cnt_basic;
-
-select flush_flow('test_numbers_basic')<=1;
-
-INSERT INTO numbers_input_basic 
-VALUES
-    (23,"2021-07-01 00:00:01.000"),
-    (24,"2021-07-01 00:00:01.500");
-
-select flush_flow('test_numbers_basic')<=1;
-
-SELECT col_0, window_start, window_end FROM out_num_cnt_basic;
-
-DROP FLOW test_numbers_basic;
-DROP TABLE numbers_input_basic;
-DROP TABLE out_num_cnt_basic;
-
--- test interprete interval
-
-CREATE TABLE numbers_input_basic (
-    number INT,
-    ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY(number),
-    TIME INDEX(ts)
-);
-create table out_num_cnt_basic (
-    number INT,
-    ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP TIME INDEX);
-
-CREATE FLOW filter_numbers_basic SINK TO out_num_cnt_basic AS SELECT INTERVAL '1 day 1 second', INTERVAL '1 month 1 day 1 second', INTERVAL '1 year 1 month' FROM numbers_input_basic where number > 10;
-
-SHOW CREATE FLOW filter_numbers_basic;
-
-drop flow filter_numbers_basic;
-
-drop table out_num_cnt_basic;
-
-drop table numbers_input_basic;
-
-CREATE TABLE bytes_log (
-    byte INT,
-    ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP, -- event time
-    TIME INDEX(ts)
-);
-
-CREATE TABLE approx_rate (
-    rate FLOAT,
-    time_window TIMESTAMP,
-    update_at TIMESTAMP,
-    TIME INDEX(time_window)
-);
-
-CREATE FLOW find_approx_rate
-SINK TO approx_rate
+CREATE FLOW ngx_aggregation
+SINK TO ngx_statistics
 AS
-SELECT CAST((max(byte) - min(byte)) AS FLOAT)/30.0, date_bin(INTERVAL '30 second', ts) as time_window from bytes_log GROUP BY time_window;
+SELECT
+    status,
+    count(client) AS total_logs,
+    min(size) as min_size,
+    max(size) as max_size,
+    avg(size) as avg_size,
+    sum(case when `size` > 550::double then 1::double else 0::double end) as high_size_count,
+    date_bin(INTERVAL '1 minutes', access_time) as time_window,
+FROM ngx_access_log
+GROUP BY
+    status,
+    time_window;
 
-INSERT INTO bytes_log VALUES 
-(101, '2025-01-01 00:00:01'),
-(300, '2025-01-01 00:00:29');
+INSERT INTO ngx_access_log
+VALUES
+    ("android", "Android", "referer", "GET", "/api/v1", "trace_id", "HTTP", 200, 1000, "agent", "2021-07-01 00:00:01.000"),
+    ("ios", "iOS", "referer", "GET", "/api/v1", "trace_id", "HTTP", 200, 500, "agent", "2021-07-01 00:00:30.500"),
+    ("android", "Android", "referer", "GET", "/api/v1", "trace_id", "HTTP", 200, 600, "agent", "2021-07-01 00:01:01.000"),
+    ("ios", "iOS", "referer", "GET", "/api/v1", "trace_id", "HTTP", 404, 700, "agent", "2021-07-01 00:01:01.500");
 
-SELECT flush_flow('find_approx_rate')<=1;
+SELECT * FROM ngx_statistics;
 
-SELECT rate, time_window FROM approx_rate;
+INSERT INTO ngx_access_log
+VALUES
+    ("android", "Android", "referer", "GET", "/api/v1", "trace_id", "HTTP", 200, 500, "agent", "2021-07-01 00:01:01.000"),
+    ("ios", "iOS", "referer", "GET", "/api/v1", "trace_id", "HTTP", 404, 800, "agent", "2021-07-01 00:01:01.500");
 
-INSERT INTO bytes_log VALUES 
-(450, '2025-01-01 00:00:32'),
-(500, '2025-01-01 00:00:37');
-
-SELECT flush_flow('find_approx_rate')<=1;
-
-SELECT rate, time_window FROM approx_rate;
-
-DROP TABLE bytes_log;
-DROP FLOW find_approx_rate;
-DROP TABLE approx_rate;
+SELECT * FROM ngx_statistics;


### PR DESCRIPTION
## What's changed

1. Set the default values back to the original resources;
2. Misc
   - Set default datanode replicas to `1`(the minimum cluster);
   - Update flow test case;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Adjusted default configuration for datanodes to improve resource efficiency by reducing default replicas from 3 to 1.
  - Introduced a new SQL script for enhanced access log data aggregation, replacing the previous numerical aggregation logic.

- **Bug Fixes**
  - Enhanced error handling and clarity in the reconciliation processes for both standalone and clustered instances, ensuring defaults are set correctly and updates are managed effectively.

- **Chores**
  - Simplified configuration files by removing explicit port definitions for HTTP, RPC, MySQL, and PostgreSQL, indicating a shift towards a more streamlined approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->