### PR TITLE
ci: add `build-operator-local-test-image` and `push-operator-local-test-image`

### DIFF
--- a/docker/initializer/Dockerfile
+++ b/docker/initializer/Dockerfile
@@ -13,4 +13,4 @@ FROM ubuntu:22.04 as base
 
 WORKDIR /greptimedb-operator
 COPY --from=builder /greptimedb-operator/bin/greptimedb-initializer /greptimedb-operator/bin/
-ENV PATH /greptimedb-operator/bin/:$PATH
+ENV PATH=/greptimedb-operator/bin/:$PATH

--- a/docker/operator/Dockerfile
+++ b/docker/operator/Dockerfile
@@ -19,6 +19,6 @@ FROM ubuntu:22.04 as base
 
 WORKDIR /greptimedb-operator
 COPY --from=builder /greptimedb-operator/bin/greptimedb-operator /greptimedb-operator/bin/
-ENV PATH /greptimedb-operator/bin/:$PATH
+ENV PATH=/greptimedb-operator/bin/:$PATH
 
 ENTRYPOINT [ "greptimedb-operator" ]

--- a/docker/operator/Dockerfile.local
+++ b/docker/operator/Dockerfile.local
@@ -1,0 +1,7 @@
+FROM ubuntu:22.04
+
+WORKDIR /greptimedb-operator
+COPY greptimedb-operator /greptimedb-operator/bin/
+ENV PATH=/greptimedb-operator/bin/:$PATH
+
+ENTRYPOINT [ "greptimedb-operator" ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new target for building the operator binary specifically for Linux environments.
	- Added targets for building and pushing a local test Docker image of the operator.
	- Created a new Dockerfile for a containerized environment using Ubuntu 22.04 for the operator.

- **Bug Fixes**
	- Standardized the syntax for setting the `PATH` environment variable in Dockerfiles, improving consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->