### PR TITLE
ci: add `TestClusterStandaloneWAL`

### DIFF
--- a/tests/e2e/greptimedbcluster_test.go
+++ b/tests/e2e/greptimedbcluster_test.go
@@ -48,4 +48,8 @@ var _ = Describe("Test GreptimeDBCluster", func() {
 	It("Test scaling a cluster up and down", func() {
 		greptimedbcluster.TestScaleCluster(ctx, h)
 	})
+
+	It("Test a cluster with standalone WAL", func() {
+		greptimedbcluster.TestClusterStandaloneWAL(ctx, h)
+	})
 })

--- a/tests/e2e/testdata/resources/cluster/standalone-wal/cluster.yaml
+++ b/tests/e2e/testdata/resources/cluster/standalone-wal/cluster.yaml
@@ -15,6 +15,10 @@ spec:
       - "etcd.etcd-cluster:2379"
   datanode:
     replicas: 1
+  httpPort: 4000
+  rpcPort: 4001
+  mysqlPort: 4002
+  postgreSQLPort: 4003
   wal:
     raftEngine:
       fs:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Introduced a new test case titled "Test a cluster with standalone WAL" to enhance the testing suite for GreptimeDBCluster functionality.
- **New Features**
	- Added configuration parameters for enhanced cluster setup, allowing specific port assignments for HTTP, RPC, MySQL, and PostgreSQL services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->