### PR TITLE
refactor: make sure operator upgrade smooth

### DIFF
--- a/controllers/greptimedbcluster/controller.go
+++ b/controllers/greptimedbcluster/controller.go
@@ -145,8 +145,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	// Update the default values to the cluster spec if it is not set.
 	if !cmp.Equal(originalObject.Spec, cluster.Spec) {
+		// Update the default values to the cluster spec if it is not set.
 		if err = r.Update(ctx, cluster); err != nil {
 			r.Recorder.Event(cluster, corev1.EventTypeWarning, "UpdateClusterFailed", fmt.Sprintf("Update cluster failed: %v", err))
 			return ctrl.Result{}, err

--- a/controllers/greptimedbstandalone/controller.go
+++ b/controllers/greptimedbstandalone/controller.go
@@ -125,8 +125,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	// Update the default values to the standalone spec if it is not set.
 	if !cmp.Equal(originalObject.Spec, standalone.Spec) {
+		// Update the default values to the standalone spec if it is not set.
 		if err = r.Update(ctx, standalone); err != nil {
 			r.Recorder.Event(standalone, corev1.EventTypeWarning, "UpdateStandaloneFailed", fmt.Sprintf("Update standalone failed: %v", err))
 			return ctrl.Result{}, err

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	dario.cat/mergo v1.0.1
+	github.com/google/go-cmp v0.6.0
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
@@ -43,7 +44,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
 	github.com/google/uuid v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/gnostic-models v0.6.8 h1:yo/ABAfM5IMRsS1VnXjTBvUb61tFIHozhlYvRgGre9I=
 github.com/google/gnostic-models v0.6.8/go.mod h1:5n7qKqH0f5wFt+aWF8CW6pZLLNOfYuF5OpfBSENuI8U=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/tests/e2e/greptimedbcluster/test_basic_cluster.go
+++ b/tests/e2e/greptimedbcluster/test_basic_cluster.go
@@ -87,7 +87,7 @@ func TestBasicCluster(ctx context.Context, h *helper.Helper) {
 	}, helper.DefaultTimeout, time.Second).Should(HaveOccurred())
 
 	By("The PVC of the datanode should be retained")
-	datanodePVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeComponentKind, nil)
+	datanodePVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeComponentKind, common.FileStorageTypeDatanode)
 	Expect(err).NotTo(HaveOccurred(), "failed to get datanode PVCs")
 	Expect(int32(len(datanodePVCs))).To(Equal(*testCluster.Spec.Datanode.Replicas), "the number of datanode PVCs should be equal to the number of datanode replicas")
 

--- a/tests/e2e/greptimedbcluster/test_cluster_enable_flow.go
+++ b/tests/e2e/greptimedbcluster/test_cluster_enable_flow.go
@@ -87,7 +87,7 @@ func TestClusterEnableFlow(ctx context.Context, h *helper.Helper) {
 	}, helper.DefaultTimeout, time.Second).Should(HaveOccurred())
 
 	By("The PVC of the datanode should be retained")
-	datanodePVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeComponentKind, nil)
+	datanodePVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeComponentKind, common.FileStorageTypeDatanode)
 	Expect(err).NotTo(HaveOccurred(), "failed to get datanode PVCs")
 	Expect(int32(len(datanodePVCs))).To(Equal(*testCluster.Spec.Datanode.Replicas), "the number of datanode PVCs should be equal to the number of datanode replicas")
 

--- a/tests/e2e/greptimedbcluster/test_cluster_enable_remote_wal.go
+++ b/tests/e2e/greptimedbcluster/test_cluster_enable_remote_wal.go
@@ -87,7 +87,7 @@ func TestClusterEnableRemoteWal(ctx context.Context, h *helper.Helper) {
 	}, helper.DefaultTimeout, time.Second).Should(HaveOccurred())
 
 	By("The PVC of the datanode should be retained")
-	datanodePVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeComponentKind, nil)
+	datanodePVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeComponentKind, common.FileStorageTypeDatanode)
 	Expect(err).NotTo(HaveOccurred(), "failed to get datanode PVCs")
 	Expect(int32(len(datanodePVCs))).To(Equal(*testCluster.Spec.Datanode.Replicas), "the number of datanode PVCs should be equal to the number of datanode replicas")
 

--- a/tests/e2e/greptimedbcluster/test_cluster_standalone_wal.go
+++ b/tests/e2e/greptimedbcluster/test_cluster_standalone_wal.go
@@ -87,13 +87,13 @@ func TestClusterStandaloneWAL(ctx context.Context, h *helper.Helper) {
 	}, helper.DefaultTimeout, time.Second).Should(HaveOccurred())
 
 	By("The PVC of the datanode should be retained")
-	datanodePVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeComponentKind, common.DatanodeFileStorageLabels)
+	datanodePVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeComponentKind, common.FileStorageTypeDatanode)
 	Expect(err).NotTo(HaveOccurred(), "failed to get datanode PVCs")
 	Expect(int32(len(datanodePVCs))).To(Equal(*testCluster.Spec.Datanode.Replicas), "the number of datanode PVCs should be equal to the number of datanode replicas")
 
 	By("The PVC of the WAL should be deleted")
 	Eventually(func() error {
-		walPVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeComponentKind, common.WALFileStorageLabels)
+		walPVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeComponentKind, common.FileStorageTypeWAL)
 		if err != nil {
 			return err
 		}

--- a/tests/e2e/greptimedbstandalone/test_basic_standalone.go
+++ b/tests/e2e/greptimedbstandalone/test_basic_standalone.go
@@ -87,7 +87,7 @@ func TestBasicStandalone(ctx context.Context, h *helper.Helper) {
 	}, helper.DefaultTimeout, time.Second).Should(HaveOccurred())
 
 	By("The PVC of the database should be retained")
-	dataPVCs, err := h.GetPVCs(ctx, testStandalone.Namespace, testStandalone.Name, greptimev1alpha1.StandaloneKind, nil)
+	dataPVCs, err := h.GetPVCs(ctx, testStandalone.Namespace, testStandalone.Name, greptimev1alpha1.StandaloneKind, common.FileStorageTypeDatanode)
 	Expect(err).NotTo(HaveOccurred(), "failed to get data PVCs")
 	Expect(len(dataPVCs)).To(Equal(1), "the number of datanode PVCs should be equal to 1")
 

--- a/tests/e2e/helper/helper.go
+++ b/tests/e2e/helper/helper.go
@@ -25,14 +25,11 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	greptimev1alpha1 "github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1"
 	"github.com/GreptimeTeam/greptimedb-operator/controllers/common"
-	"github.com/GreptimeTeam/greptimedb-operator/controllers/constant"
-	"github.com/GreptimeTeam/greptimedb-operator/pkg/util"
 )
 
 const (
@@ -125,30 +122,8 @@ func (h *Helper) GetPhase(ctx context.Context, namespace, name string, object cl
 }
 
 // GetPVCs returns the PVC list of the given component.
-func (h *Helper) GetPVCs(ctx context.Context, namespace, name string, kind greptimev1alpha1.ComponentKind, additionalLabels map[string]string) ([]corev1.PersistentVolumeClaim, error) {
-	matachedLabels := map[string]string{
-		constant.GreptimeDBComponentName: common.ResourceName(name, kind),
-	}
-
-	if additionalLabels != nil {
-		matachedLabels = util.MergeStringMap(matachedLabels, additionalLabels)
-	}
-
-	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
-		MatchLabels: matachedLabels,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	claims := new(corev1.PersistentVolumeClaimList)
-
-	if err = h.List(ctx, claims, client.InNamespace(namespace),
-		client.MatchingLabelsSelector{Selector: selector}); err != nil {
-		return nil, err
-	}
-
-	return claims.Items, nil
+func (h *Helper) GetPVCs(ctx context.Context, namespace, name string, kind greptimev1alpha1.ComponentKind, fsType common.FileStorageType) ([]corev1.PersistentVolumeClaim, error) {
+	return common.GetPVCs(ctx, h.Client, namespace, name, kind, fsType)
 }
 
 // CleanEtcdData cleans up all data in etcd by executing the etcdctl command in the given pod.


### PR DESCRIPTION
## What's changed

1. Update the default values to the spec if it is not set. 
2. Add `FileStorageType` and don't need to add labels for datanode storage because of the statefulset doesn't support to modify PVC labels;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new constant for file storage type labels and streamlined PVC handling based on storage types.
	- Added a function to retrieve PVCs based on specified parameters, enhancing flexibility in storage management.

- **Improvements**
	- Refactored logic in cluster initialization and updates for better clarity and maintenance.
	- Updated test cases to specify storage types when retrieving PVCs, ensuring precise management of resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->