### PR TITLE
refactor:  sperate ports config from frontend instance and service

### DIFF
--- a/apis/v1alpha1/defaulting.go
+++ b/apis/v1alpha1/defaulting.go
@@ -87,6 +87,10 @@ func (in *GreptimeDBCluster) defaultFrontend() *FrontendSpec {
 			Template: &PodTemplateSpec{},
 			Replicas: pointer.Int32(DefaultReplicas),
 		},
+		RPCPort:        DefaultRPCPort,
+		HTTPPort:       DefaultHTTPPort,
+		MySQLPort:      DefaultMySQLPort,
+		PostgreSQLPort: DefaultPostgreSQLPort,
 		Service: &ServiceSpec{
 			Type: corev1.ServiceTypeClusterIP,
 		},
@@ -159,7 +163,7 @@ func (in *GreptimeDBCluster) mergeFrontendTemplate() error {
 		}
 
 		// Reconfigure the probe settings based on the HTTP port.
-		in.Spec.Frontend.Template.MainContainer.LivenessProbe.HTTPGet.Port = intstr.FromInt32(in.Spec.HTTPPort)
+		in.Spec.Frontend.Template.MainContainer.LivenessProbe.HTTPGet.Port = intstr.FromInt32(in.Spec.Frontend.HTTPPort)
 	}
 
 	return nil

--- a/apis/v1alpha1/greptimedbcluster_types.go
+++ b/apis/v1alpha1/greptimedbcluster_types.go
@@ -43,10 +43,14 @@ type MetaSpec struct {
 	ComponentSpec `json:",inline"`
 
 	// RPCPort is the gRPC port of the meta.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=65535
 	// +optional
 	RPCPort int32 `json:"rpcPort,omitempty"`
 
 	// HTTPPort is the HTTP port of the meta.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=65535
 	// +optional
 	HTTPPort int32 `json:"httpPort,omitempty"`
 
@@ -107,6 +111,30 @@ func (in *MetaSpec) IsEnableCheckEtcdService() bool {
 type FrontendSpec struct {
 	ComponentSpec `json:",inline"`
 
+	// RPCPort is the gRPC port of the frontend.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=65535
+	// +optional
+	RPCPort int32 `json:"rpcPort,omitempty"`
+
+	// HTTPPort is the HTTP port of the frontend.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=65535
+	// +optional
+	HTTPPort int32 `json:"httpPort,omitempty"`
+
+	// MySQLPort is the MySQL port of the frontend.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=65535
+	// +optional
+	MySQLPort int32 `json:"mysqlPort,omitempty"`
+
+	// PostgreSQLPort is the PostgreSQL port of the frontend.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=65535
+	// +optional
+	PostgreSQLPort int32 `json:"postgreSQLPort,omitempty"`
+
 	// Service is the service configuration of the frontend.
 	// +optional
 	Service *ServiceSpec `json:"service,omitempty"`
@@ -149,10 +177,14 @@ type DatanodeSpec struct {
 	ComponentSpec `json:",inline"`
 
 	// RPCPort is the gRPC port of the datanode.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=65535
 	// +optional
 	RPCPort int32 `json:"rpcPort,omitempty"`
 
 	// HTTPPort is the HTTP port of the datanode.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=65535
 	// +optional
 	HTTPPort int32 `json:"httpPort,omitempty"`
 
@@ -194,6 +226,8 @@ type FlownodeSpec struct {
 	ComponentSpec `json:",inline"`
 
 	// The gRPC port of the flownode.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=65535
 	// +optional
 	RPCPort int32 `json:"rpcPort,omitempty"`
 }
@@ -242,18 +276,26 @@ type GreptimeDBClusterSpec struct {
 	Flownode *FlownodeSpec `json:"flownode,omitempty"`
 
 	// HTTPPort is the HTTP port of the greptimedb cluster.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=65535
 	// +optional
 	HTTPPort int32 `json:"httpPort,omitempty"`
 
 	// RPCPort is the RPC port of the greptimedb cluster.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=65535
 	// +optional
 	RPCPort int32 `json:"rpcPort,omitempty"`
 
 	// MySQLPort is the MySQL port of the greptimedb cluster.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=65535
 	// +optional
 	MySQLPort int32 `json:"mysqlPort,omitempty"`
 
 	// PostgreSQLPort is the PostgreSQL port of the greptimedb cluster.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=65535
 	// +optional
 	PostgreSQLPort int32 `json:"postgreSQLPort,omitempty"`
 

--- a/apis/v1alpha1/greptimedbstandalone_types.go
+++ b/apis/v1alpha1/greptimedbstandalone_types.go
@@ -33,18 +33,26 @@ type GreptimeDBStandaloneSpec struct {
 	TLS *TLSSpec `json:"tls,omitempty"`
 
 	// HTTPPort is the port of the greptimedb http service.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=65535
 	// +optional
 	HTTPPort int32 `json:"httpPort,omitempty"`
 
 	// RPCPort is the port of the greptimedb rpc service.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=65535
 	// +optional
 	RPCPort int32 `json:"rpcPort,omitempty"`
 
 	// MySQLPort is the port of the greptimedb mysql service.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=65535
 	// +optional
 	MySQLPort int32 `json:"mysqlPort,omitempty"`
 
 	// PostgreSQLPort is the port of the greptimedb postgresql service.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=65535
 	// +optional
 	PostgreSQLPort int32 `json:"postgreSQLPort,omitempty"`
 

--- a/apis/v1alpha1/testdata/defaulting/greptimedbcluster/test00/expect.yaml
+++ b/apis/v1alpha1/testdata/defaulting/greptimedbcluster/test00/expect.yaml
@@ -26,6 +26,10 @@ spec:
           port: 4000
   frontend:
     replicas: 1
+    httpPort: 4000
+    mysqlPort: 4002
+    postgreSQLPort: 4003
+    rpcPort: 4001
     service:
       type: ClusterIP
     template:
@@ -34,7 +38,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /health
-            port: 5000
+            port: 4000
   meta:
     etcdEndpoints:
       - etcd.etcd-cluster.svc.cluster.local:2379

--- a/apis/v1alpha1/testdata/defaulting/greptimedbcluster/test01/expect.yaml
+++ b/apis/v1alpha1/testdata/defaulting/greptimedbcluster/test01/expect.yaml
@@ -33,6 +33,10 @@ spec:
           memory: "1Gi"
   frontend:
     replicas: 1
+    httpPort: 4000
+    mysqlPort: 4002
+    postgreSQLPort: 4003
+    rpcPort: 4001
     service:
       type: ClusterIP
     template:

--- a/apis/v1alpha1/testdata/defaulting/greptimedbcluster/test02/expect.yaml
+++ b/apis/v1alpha1/testdata/defaulting/greptimedbcluster/test02/expect.yaml
@@ -37,6 +37,10 @@ spec:
           port: 4000
   frontend:
     replicas: 1
+    httpPort: 4000
+    mysqlPort: 4002
+    postgreSQLPort: 4003
+    rpcPort: 4001
     service:
       type: ClusterIP
     template:

--- a/config/crd/resources/greptime.io_greptimedbclusters.yaml
+++ b/config/crd/resources/greptime.io_greptimedbclusters.yaml
@@ -2818,6 +2818,8 @@ spec:
                     type: string
                   httpPort:
                     format: int32
+                    maximum: 65535
+                    minimum: 0
                     type: integer
                   logging:
                     properties:
@@ -2846,6 +2848,8 @@ spec:
                     type: integer
                   rpcPort:
                     format: int32
+                    maximum: 65535
+                    minimum: 0
                     type: integer
                   storage:
                     properties:
@@ -5663,6 +5667,8 @@ spec:
                     type: integer
                   rpcPort:
                     format: int32
+                    maximum: 65535
+                    minimum: 0
                     type: integer
                   template:
                     properties:
@@ -8431,6 +8437,11 @@ spec:
                 properties:
                   config:
                     type: string
+                  httpPort:
+                    format: int32
+                    maximum: 65535
+                    minimum: 0
+                    type: integer
                   logging:
                     properties:
                       format:
@@ -8452,8 +8463,23 @@ spec:
                       persistentWithData:
                         type: boolean
                     type: object
+                  mysqlPort:
+                    format: int32
+                    maximum: 65535
+                    minimum: 0
+                    type: integer
+                  postgreSQLPort:
+                    format: int32
+                    maximum: 65535
+                    minimum: 0
+                    type: integer
                   replicas:
                     format: int32
+                    minimum: 0
+                    type: integer
+                  rpcPort:
+                    format: int32
+                    maximum: 65535
                     minimum: 0
                     type: integer
                   service:
@@ -11243,6 +11269,8 @@ spec:
                 type: object
               httpPort:
                 format: int32
+                maximum: 65535
+                minimum: 0
                 type: integer
               initializer:
                 properties:
@@ -11284,6 +11312,8 @@ spec:
                     type: array
                   httpPort:
                     format: int32
+                    maximum: 65535
+                    minimum: 0
                     type: integer
                   logging:
                     properties:
@@ -11312,6 +11342,8 @@ spec:
                     type: integer
                   rpcPort:
                     format: int32
+                    maximum: 65535
+                    minimum: 0
                     type: integer
                   storeKeyPrefix:
                     type: string
@@ -14082,6 +14114,8 @@ spec:
                 type: object
               mysqlPort:
                 format: int32
+                maximum: 65535
+                minimum: 0
                 type: integer
               objectStorage:
                 properties:
@@ -14160,6 +14194,8 @@ spec:
                 type: object
               postgreSQLPort:
                 format: int32
+                maximum: 65535
+                minimum: 0
                 type: integer
               prometheusMonitor:
                 properties:
@@ -14176,6 +14212,8 @@ spec:
                 type: object
               rpcPort:
                 format: int32
+                maximum: 65535
+                minimum: 0
                 type: integer
               version:
                 type: string

--- a/config/crd/resources/greptime.io_greptimedbstandalones.yaml
+++ b/config/crd/resources/greptime.io_greptimedbstandalones.yaml
@@ -2826,6 +2826,8 @@ spec:
                 type: object
               httpPort:
                 format: int32
+                maximum: 65535
+                minimum: 0
                 type: integer
               initializer:
                 properties:
@@ -2855,6 +2857,8 @@ spec:
                 type: object
               mysqlPort:
                 format: int32
+                maximum: 65535
+                minimum: 0
                 type: integer
               objectStorage:
                 properties:
@@ -2933,6 +2937,8 @@ spec:
                 type: object
               postgreSQLPort:
                 format: int32
+                maximum: 65535
+                minimum: 0
                 type: integer
               prometheusMonitor:
                 properties:
@@ -2949,6 +2955,8 @@ spec:
                 type: object
               rpcPort:
                 format: int32
+                maximum: 65535
+                minimum: 0
                 type: integer
               service:
                 properties:

--- a/controllers/greptimedbcluster/deployers/frontend.go
+++ b/controllers/greptimedbcluster/deployers/frontend.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -237,12 +238,12 @@ func (b *frontendBuilder) Generate() ([]client.Object, error) {
 func (b *frontendBuilder) generateMainContainerArgs() []string {
 	var args = []string{
 		"frontend", "start",
-		"--rpc-addr", fmt.Sprintf("0.0.0.0:%d", b.Cluster.Spec.RPCPort),
+		"--rpc-addr", fmt.Sprintf("0.0.0.0:%d", b.Cluster.Spec.Frontend.RPCPort),
 		"--metasrv-addrs", fmt.Sprintf("%s.%s:%d", common.ResourceName(b.Cluster.Name, v1alpha1.MetaComponentKind),
 			b.Cluster.Namespace, b.Cluster.Spec.Meta.RPCPort),
-		"--http-addr", fmt.Sprintf("0.0.0.0:%d", b.Cluster.Spec.HTTPPort),
-		"--mysql-addr", fmt.Sprintf("0.0.0.0:%d", b.Cluster.Spec.MySQLPort),
-		"--postgres-addr", fmt.Sprintf("0.0.0.0:%d", b.Cluster.Spec.PostgreSQLPort),
+		"--http-addr", fmt.Sprintf("0.0.0.0:%d", b.Cluster.Spec.Frontend.HTTPPort),
+		"--mysql-addr", fmt.Sprintf("0.0.0.0:%d", b.Cluster.Spec.Frontend.MySQLPort),
+		"--postgres-addr", fmt.Sprintf("0.0.0.0:%d", b.Cluster.Spec.Frontend.PostgreSQLPort),
 		"--config-file", path.Join(constant.GreptimeDBConfigDir, constant.GreptimeDBConfigFileName),
 	}
 
@@ -307,24 +308,28 @@ func (b *frontendBuilder) mountTLSSecret(template *corev1.PodTemplateSpec) {
 func (b *frontendBuilder) servicePorts() []corev1.ServicePort {
 	return []corev1.ServicePort{
 		{
-			Name:     "rpc",
-			Protocol: corev1.ProtocolTCP,
-			Port:     b.Cluster.Spec.RPCPort,
+			Name:       "rpc",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       b.Cluster.Spec.RPCPort,
+			TargetPort: intstr.FromInt32(b.Cluster.Spec.Frontend.RPCPort),
 		},
 		{
-			Name:     "http",
-			Protocol: corev1.ProtocolTCP,
-			Port:     b.Cluster.Spec.HTTPPort,
+			Name:       "http",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       b.Cluster.Spec.HTTPPort,
+			TargetPort: intstr.FromInt32(b.Cluster.Spec.Frontend.HTTPPort),
 		},
 		{
-			Name:     "mysql",
-			Protocol: corev1.ProtocolTCP,
-			Port:     b.Cluster.Spec.MySQLPort,
+			Name:       "mysql",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       b.Cluster.Spec.MySQLPort,
+			TargetPort: intstr.FromInt32(b.Cluster.Spec.Frontend.MySQLPort),
 		},
 		{
-			Name:     "pg",
-			Protocol: corev1.ProtocolTCP,
-			Port:     b.Cluster.Spec.PostgreSQLPort,
+			Name:       "pg",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       b.Cluster.Spec.PostgreSQLPort,
+			TargetPort: intstr.FromInt32(b.Cluster.Spec.Frontend.PostgreSQLPort),
 		},
 	}
 }
@@ -334,22 +339,22 @@ func (b *frontendBuilder) containerPorts() []corev1.ContainerPort {
 		{
 			Name:          "rpc",
 			Protocol:      corev1.ProtocolTCP,
-			ContainerPort: b.Cluster.Spec.RPCPort,
+			ContainerPort: b.Cluster.Spec.Frontend.RPCPort,
 		},
 		{
 			Name:          "http",
 			Protocol:      corev1.ProtocolTCP,
-			ContainerPort: b.Cluster.Spec.HTTPPort,
+			ContainerPort: b.Cluster.Spec.Frontend.HTTPPort,
 		},
 		{
 			Name:          "mysql",
 			Protocol:      corev1.ProtocolTCP,
-			ContainerPort: b.Cluster.Spec.MySQLPort,
+			ContainerPort: b.Cluster.Spec.Frontend.MySQLPort,
 		},
 		{
 			Name:          "pg",
 			Protocol:      corev1.ProtocolTCP,
-			ContainerPort: b.Cluster.Spec.PostgreSQLPort,
+			ContainerPort: b.Cluster.Spec.Frontend.PostgreSQLPort,
 		},
 	}
 }

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -111,8 +111,8 @@ _Appears in:_
 | `config` _string_ | The content of the configuration file of the component in TOML format. |  |  |
 | `template` _[PodTemplateSpec](#podtemplatespec)_ | Template defines the pod template for the component, if not specified, the pod template will use the default value. |  |  |
 | `logging` _[LoggingSpec](#loggingspec)_ | Logging defines the logging configuration for the component. |  |  |
-| `rpcPort` _integer_ | RPCPort is the gRPC port of the datanode. |  |  |
-| `httpPort` _integer_ | HTTPPort is the HTTP port of the datanode. |  |  |
+| `rpcPort` _integer_ | RPCPort is the gRPC port of the datanode. |  | Maximum: 65535 <br />Minimum: 0 <br /> |
+| `httpPort` _integer_ | HTTPPort is the HTTP port of the datanode. |  | Maximum: 65535 <br />Minimum: 0 <br /> |
 | `storage` _[DatanodeStorageSpec](#datanodestoragespec)_ | Storage is the default file storage of the datanode. For example, WAL, cache, index etc. |  |  |
 
 
@@ -192,7 +192,7 @@ _Appears in:_
 | `config` _string_ | The content of the configuration file of the component in TOML format. |  |  |
 | `template` _[PodTemplateSpec](#podtemplatespec)_ | Template defines the pod template for the component, if not specified, the pod template will use the default value. |  |  |
 | `logging` _[LoggingSpec](#loggingspec)_ | Logging defines the logging configuration for the component. |  |  |
-| `rpcPort` _integer_ | The gRPC port of the flownode. |  |  |
+| `rpcPort` _integer_ | The gRPC port of the flownode. |  | Maximum: 65535 <br />Minimum: 0 <br /> |
 
 
 #### FlownodeStatus
@@ -229,6 +229,10 @@ _Appears in:_
 | `config` _string_ | The content of the configuration file of the component in TOML format. |  |  |
 | `template` _[PodTemplateSpec](#podtemplatespec)_ | Template defines the pod template for the component, if not specified, the pod template will use the default value. |  |  |
 | `logging` _[LoggingSpec](#loggingspec)_ | Logging defines the logging configuration for the component. |  |  |
+| `rpcPort` _integer_ | RPCPort is the gRPC port of the frontend. |  | Maximum: 65535 <br />Minimum: 0 <br /> |
+| `httpPort` _integer_ | HTTPPort is the HTTP port of the frontend. |  | Maximum: 65535 <br />Minimum: 0 <br /> |
+| `mysqlPort` _integer_ | MySQLPort is the MySQL port of the frontend. |  | Maximum: 65535 <br />Minimum: 0 <br /> |
+| `postgreSQLPort` _integer_ | PostgreSQLPort is the PostgreSQL port of the frontend. |  | Maximum: 65535 <br />Minimum: 0 <br /> |
 | `service` _[ServiceSpec](#servicespec)_ | Service is the service configuration of the frontend. |  |  |
 | `tls` _[TLSSpec](#tlsspec)_ | TLS is the TLS configuration of the frontend. |  |  |
 
@@ -325,10 +329,10 @@ _Appears in:_
 | `meta` _[MetaSpec](#metaspec)_ | Meta is the specification of meta node. |  |  |
 | `datanode` _[DatanodeSpec](#datanodespec)_ | Datanode is the specification of datanode node. |  |  |
 | `flownode` _[FlownodeSpec](#flownodespec)_ | Flownode is the specification of flownode node. |  |  |
-| `httpPort` _integer_ | HTTPPort is the HTTP port of the greptimedb cluster. |  |  |
-| `rpcPort` _integer_ | RPCPort is the RPC port of the greptimedb cluster. |  |  |
-| `mysqlPort` _integer_ | MySQLPort is the MySQL port of the greptimedb cluster. |  |  |
-| `postgreSQLPort` _integer_ | PostgreSQLPort is the PostgreSQL port of the greptimedb cluster. |  |  |
+| `httpPort` _integer_ | HTTPPort is the HTTP port of the greptimedb cluster. |  | Maximum: 65535 <br />Minimum: 0 <br /> |
+| `rpcPort` _integer_ | RPCPort is the RPC port of the greptimedb cluster. |  | Maximum: 65535 <br />Minimum: 0 <br /> |
+| `mysqlPort` _integer_ | MySQLPort is the MySQL port of the greptimedb cluster. |  | Maximum: 65535 <br />Minimum: 0 <br /> |
+| `postgreSQLPort` _integer_ | PostgreSQLPort is the PostgreSQL port of the greptimedb cluster. |  | Maximum: 65535 <br />Minimum: 0 <br /> |
 | `prometheusMonitor` _[PrometheusMonitorSpec](#prometheusmonitorspec)_ | PrometheusMonitor is the specification for creating PodMonitor or ServiceMonitor. |  |  |
 | `version` _string_ | Version is the version of greptimedb. |  |  |
 | `initializer` _[InitializerSpec](#initializerspec)_ | Initializer is the init container to set up components configurations before running the container. |  |  |
@@ -392,10 +396,10 @@ _Appears in:_
 | `base` _[PodTemplateSpec](#podtemplatespec)_ | Base is the base pod template for all components and can be overridden by template of individual component. |  |  |
 | `service` _[ServiceSpec](#servicespec)_ | Service is the service configuration of greptimedb. |  |  |
 | `tls` _[TLSSpec](#tlsspec)_ | The TLS configurations of the greptimedb. |  |  |
-| `httpPort` _integer_ | HTTPPort is the port of the greptimedb http service. |  |  |
-| `rpcPort` _integer_ | RPCPort is the port of the greptimedb rpc service. |  |  |
-| `mysqlPort` _integer_ | MySQLPort is the port of the greptimedb mysql service. |  |  |
-| `postgreSQLPort` _integer_ | PostgreSQLPort is the port of the greptimedb postgresql service. |  |  |
+| `httpPort` _integer_ | HTTPPort is the port of the greptimedb http service. |  | Maximum: 65535 <br />Minimum: 0 <br /> |
+| `rpcPort` _integer_ | RPCPort is the port of the greptimedb rpc service. |  | Maximum: 65535 <br />Minimum: 0 <br /> |
+| `mysqlPort` _integer_ | MySQLPort is the port of the greptimedb mysql service. |  | Maximum: 65535 <br />Minimum: 0 <br /> |
+| `postgreSQLPort` _integer_ | PostgreSQLPort is the port of the greptimedb postgresql service. |  | Maximum: 65535 <br />Minimum: 0 <br /> |
 | `prometheusMonitor` _[PrometheusMonitorSpec](#prometheusmonitorspec)_ | PrometheusMonitor is the specification for creating PodMonitor or ServiceMonitor. |  |  |
 | `version` _string_ | Version is the version of the greptimedb. |  |  |
 | `initializer` _[InitializerSpec](#initializerspec)_ | Initializer is the init container to set up components configurations before running the container. |  |  |
@@ -547,8 +551,8 @@ _Appears in:_
 | `config` _string_ | The content of the configuration file of the component in TOML format. |  |  |
 | `template` _[PodTemplateSpec](#podtemplatespec)_ | Template defines the pod template for the component, if not specified, the pod template will use the default value. |  |  |
 | `logging` _[LoggingSpec](#loggingspec)_ | Logging defines the logging configuration for the component. |  |  |
-| `rpcPort` _integer_ | RPCPort is the gRPC port of the meta. |  |  |
-| `httpPort` _integer_ | HTTPPort is the HTTP port of the meta. |  |  |
+| `rpcPort` _integer_ | RPCPort is the gRPC port of the meta. |  | Maximum: 65535 <br />Minimum: 0 <br /> |
+| `httpPort` _integer_ | HTTPPort is the HTTP port of the meta. |  | Maximum: 65535 <br />Minimum: 0 <br /> |
 | `etcdEndpoints` _string array_ | EtcdEndpoints is the endpoints of the etcd cluster. |  |  |
 | `enableCheckEtcdService` _boolean_ | EnableCheckEtcdService indicates whether to check etcd cluster health when starting meta. |  |  |
 | `enableRegionFailover` _boolean_ | EnableRegionFailover indicates whether to enable region failover. |  |  |

--- a/manifests/bundle.yaml
+++ b/manifests/bundle.yaml
@@ -2824,6 +2824,8 @@ spec:
                     type: string
                   httpPort:
                     format: int32
+                    maximum: 65535
+                    minimum: 0
                     type: integer
                   logging:
                     properties:
@@ -2852,6 +2854,8 @@ spec:
                     type: integer
                   rpcPort:
                     format: int32
+                    maximum: 65535
+                    minimum: 0
                     type: integer
                   storage:
                     properties:
@@ -5669,6 +5673,8 @@ spec:
                     type: integer
                   rpcPort:
                     format: int32
+                    maximum: 65535
+                    minimum: 0
                     type: integer
                   template:
                     properties:
@@ -8437,6 +8443,11 @@ spec:
                 properties:
                   config:
                     type: string
+                  httpPort:
+                    format: int32
+                    maximum: 65535
+                    minimum: 0
+                    type: integer
                   logging:
                     properties:
                       format:
@@ -8458,8 +8469,23 @@ spec:
                       persistentWithData:
                         type: boolean
                     type: object
+                  mysqlPort:
+                    format: int32
+                    maximum: 65535
+                    minimum: 0
+                    type: integer
+                  postgreSQLPort:
+                    format: int32
+                    maximum: 65535
+                    minimum: 0
+                    type: integer
                   replicas:
                     format: int32
+                    minimum: 0
+                    type: integer
+                  rpcPort:
+                    format: int32
+                    maximum: 65535
                     minimum: 0
                     type: integer
                   service:
@@ -11249,6 +11275,8 @@ spec:
                 type: object
               httpPort:
                 format: int32
+                maximum: 65535
+                minimum: 0
                 type: integer
               initializer:
                 properties:
@@ -11290,6 +11318,8 @@ spec:
                     type: array
                   httpPort:
                     format: int32
+                    maximum: 65535
+                    minimum: 0
                     type: integer
                   logging:
                     properties:
@@ -11318,6 +11348,8 @@ spec:
                     type: integer
                   rpcPort:
                     format: int32
+                    maximum: 65535
+                    minimum: 0
                     type: integer
                   storeKeyPrefix:
                     type: string
@@ -14088,6 +14120,8 @@ spec:
                 type: object
               mysqlPort:
                 format: int32
+                maximum: 65535
+                minimum: 0
                 type: integer
               objectStorage:
                 properties:
@@ -14166,6 +14200,8 @@ spec:
                 type: object
               postgreSQLPort:
                 format: int32
+                maximum: 65535
+                minimum: 0
                 type: integer
               prometheusMonitor:
                 properties:
@@ -14182,6 +14218,8 @@ spec:
                 type: object
               rpcPort:
                 format: int32
+                maximum: 65535
+                minimum: 0
                 type: integer
               version:
                 type: string
@@ -17139,6 +17177,8 @@ spec:
                 type: object
               httpPort:
                 format: int32
+                maximum: 65535
+                minimum: 0
                 type: integer
               initializer:
                 properties:
@@ -17168,6 +17208,8 @@ spec:
                 type: object
               mysqlPort:
                 format: int32
+                maximum: 65535
+                minimum: 0
                 type: integer
               objectStorage:
                 properties:
@@ -17246,6 +17288,8 @@ spec:
                 type: object
               postgreSQLPort:
                 format: int32
+                maximum: 65535
+                minimum: 0
                 type: integer
               prometheusMonitor:
                 properties:
@@ -17262,6 +17306,8 @@ spec:
                 type: object
               rpcPort:
                 format: int32
+                maximum: 65535
+                minimum: 0
                 type: integer
               service:
                 properties:

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -2817,6 +2817,8 @@ spec:
                     type: string
                   httpPort:
                     format: int32
+                    maximum: 65535
+                    minimum: 0
                     type: integer
                   logging:
                     properties:
@@ -2845,6 +2847,8 @@ spec:
                     type: integer
                   rpcPort:
                     format: int32
+                    maximum: 65535
+                    minimum: 0
                     type: integer
                   storage:
                     properties:
@@ -5662,6 +5666,8 @@ spec:
                     type: integer
                   rpcPort:
                     format: int32
+                    maximum: 65535
+                    minimum: 0
                     type: integer
                   template:
                     properties:
@@ -8430,6 +8436,11 @@ spec:
                 properties:
                   config:
                     type: string
+                  httpPort:
+                    format: int32
+                    maximum: 65535
+                    minimum: 0
+                    type: integer
                   logging:
                     properties:
                       format:
@@ -8451,8 +8462,23 @@ spec:
                       persistentWithData:
                         type: boolean
                     type: object
+                  mysqlPort:
+                    format: int32
+                    maximum: 65535
+                    minimum: 0
+                    type: integer
+                  postgreSQLPort:
+                    format: int32
+                    maximum: 65535
+                    minimum: 0
+                    type: integer
                   replicas:
                     format: int32
+                    minimum: 0
+                    type: integer
+                  rpcPort:
+                    format: int32
+                    maximum: 65535
                     minimum: 0
                     type: integer
                   service:
@@ -11242,6 +11268,8 @@ spec:
                 type: object
               httpPort:
                 format: int32
+                maximum: 65535
+                minimum: 0
                 type: integer
               initializer:
                 properties:
@@ -11283,6 +11311,8 @@ spec:
                     type: array
                   httpPort:
                     format: int32
+                    maximum: 65535
+                    minimum: 0
                     type: integer
                   logging:
                     properties:
@@ -11311,6 +11341,8 @@ spec:
                     type: integer
                   rpcPort:
                     format: int32
+                    maximum: 65535
+                    minimum: 0
                     type: integer
                   storeKeyPrefix:
                     type: string
@@ -14081,6 +14113,8 @@ spec:
                 type: object
               mysqlPort:
                 format: int32
+                maximum: 65535
+                minimum: 0
                 type: integer
               objectStorage:
                 properties:
@@ -14159,6 +14193,8 @@ spec:
                 type: object
               postgreSQLPort:
                 format: int32
+                maximum: 65535
+                minimum: 0
                 type: integer
               prometheusMonitor:
                 properties:
@@ -14175,6 +14211,8 @@ spec:
                 type: object
               rpcPort:
                 format: int32
+                maximum: 65535
+                minimum: 0
                 type: integer
               version:
                 type: string
@@ -17132,6 +17170,8 @@ spec:
                 type: object
               httpPort:
                 format: int32
+                maximum: 65535
+                minimum: 0
                 type: integer
               initializer:
                 properties:
@@ -17161,6 +17201,8 @@ spec:
                 type: object
               mysqlPort:
                 format: int32
+                maximum: 65535
+                minimum: 0
                 type: integer
               objectStorage:
                 properties:
@@ -17239,6 +17281,8 @@ spec:
                 type: object
               postgreSQLPort:
                 format: int32
+                maximum: 65535
+                minimum: 0
                 type: integer
               prometheusMonitor:
                 properties:
@@ -17255,6 +17299,8 @@ spec:
                 type: object
               rpcPort:
                 format: int32
+                maximum: 65535
+                minimum: 0
                 type: integer
               service:
                 properties:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added configuration options for `RPCPort`, `HTTPPort`, `MySQLPort`, and `PostgreSQLPort` to enhance service communication capabilities.
	- Updated liveness probe configuration to utilize the new HTTP port.

- **Bug Fixes**
	- Ensured liveness probe correctly references the updated HTTP port within the frontend configuration.

- **Documentation**
	- Enhanced API documentation to include new port configuration fields for frontend services, specifying valid ranges.

- **Configuration**
	- Updated various configuration files to support the new port settings, improving the overall flexibility of service configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->