### PR TITLE
refactor(monitoring): remove monitoring resources when disabled

### DIFF
--- a/controllers/greptimedbcluster/deployers/datanode.go
+++ b/controllers/greptimedbcluster/deployers/datanode.go
@@ -459,7 +459,7 @@ func (b *datanodeBuilder) generatePodTemplateSpec() corev1.PodTemplateSpec {
 		b.AddLogsVolume(podTemplateSpec, logging.GetLogsDir())
 	}
 
-	if b.Cluster.GetMonitoring() != nil && b.Cluster.GetMonitoring().GetVector() != nil {
+	if b.Cluster.GetMonitoring().IsEnabled() && b.Cluster.GetMonitoring().GetVector() != nil {
 		b.AddVectorConfigVolume(podTemplateSpec)
 		b.AddVectorSidecar(podTemplateSpec, v1alpha1.DatanodeComponentKind)
 	}

--- a/controllers/greptimedbcluster/deployers/flownode.go
+++ b/controllers/greptimedbcluster/deployers/flownode.go
@@ -260,7 +260,7 @@ func (b *flownodeBuilder) generatePodTemplateSpec() corev1.PodTemplateSpec {
 		b.AddLogsVolume(podTemplateSpec, logging.GetLogsDir())
 	}
 
-	if b.Cluster.GetMonitoring() != nil && b.Cluster.GetMonitoring().GetVector() != nil {
+	if b.Cluster.GetMonitoring().IsEnabled() && b.Cluster.GetMonitoring().GetVector() != nil {
 		b.AddVectorConfigVolume(podTemplateSpec)
 		b.AddVectorSidecar(podTemplateSpec, v1alpha1.FlownodeComponentKind)
 	}

--- a/controllers/greptimedbcluster/deployers/frontend.go
+++ b/controllers/greptimedbcluster/deployers/frontend.go
@@ -279,7 +279,7 @@ func (b *frontendBuilder) generatePodTemplateSpec() *corev1.PodTemplateSpec {
 		b.AddLogsVolume(podTemplateSpec, logging.GetLogsDir())
 	}
 
-	if b.Cluster.GetMonitoring() != nil && b.Cluster.GetMonitoring().GetVector() != nil {
+	if b.Cluster.GetMonitoring().IsEnabled() && b.Cluster.GetMonitoring().GetVector() != nil {
 		b.AddVectorConfigVolume(podTemplateSpec)
 		b.AddVectorSidecar(podTemplateSpec, v1alpha1.FrontendComponentKind)
 	}

--- a/controllers/greptimedbcluster/deployers/meta.go
+++ b/controllers/greptimedbcluster/deployers/meta.go
@@ -329,7 +329,7 @@ func (b *metaBuilder) generatePodTemplateSpec() *corev1.PodTemplateSpec {
 		b.AddLogsVolume(podTemplateSpec, logging.GetLogsDir())
 	}
 
-	if b.Cluster.GetMonitoring() != nil && b.Cluster.GetMonitoring().GetVector() != nil {
+	if b.Cluster.GetMonitoring().IsEnabled() && b.Cluster.GetMonitoring().GetVector() != nil {
 		b.AddVectorConfigVolume(podTemplateSpec)
 		b.AddVectorSidecar(podTemplateSpec, v1alpha1.MetaComponentKind)
 	}

--- a/controllers/greptimedbcluster/deployers/monitoring.go
+++ b/controllers/greptimedbcluster/deployers/monitoring.go
@@ -74,7 +74,7 @@ func (d *MonitoringDeployer) CheckAndUpdateStatus(ctx context.Context, crdObject
 		return false, err
 	}
 
-	if cluster.GetMonitoring() == nil || cluster.GetMonitoring().GetStandalone() == nil {
+	if !cluster.GetMonitoring().IsEnabled() || cluster.GetMonitoring().GetStandalone() == nil {
 		return true, nil
 	}
 
@@ -92,7 +92,7 @@ func (d *MonitoringDeployer) CheckAndUpdateStatus(ctx context.Context, crdObject
 		return false, nil
 	}
 
-	if standalone.Status.StandalonePhase == v1alpha1.PhaseRunning {
+	if cluster.GetMonitoring().IsEnabled() && standalone.Status.StandalonePhase == v1alpha1.PhaseRunning {
 		if err := d.createPipeline(cluster); err != nil {
 			klog.Errorf("failed to create pipeline for standalone, err: '%v'", err)
 			return false, err
@@ -196,7 +196,7 @@ type monitoringBuilder struct {
 }
 
 func (b *monitoringBuilder) BuildGreptimeDBStandalone() deployer.Builder {
-	if b.Cluster.GetMonitoring() == nil || b.Cluster.GetMonitoring().GetStandalone() == nil {
+	if !b.Cluster.GetMonitoring().IsEnabled() || b.Cluster.GetMonitoring().GetStandalone() == nil {
 		return b
 	}
 
@@ -222,7 +222,7 @@ func (b *monitoringBuilder) BuildGreptimeDBStandalone() deployer.Builder {
 }
 
 func (b *monitoringBuilder) BuildConfigMap() deployer.Builder {
-	if b.Cluster.GetMonitoring() == nil || b.Cluster.GetMonitoring().GetVector() == nil {
+	if !b.Cluster.GetMonitoring().IsEnabled() || b.Cluster.GetMonitoring().GetVector() == nil {
 		return b
 	}
 

--- a/tests/e2e/greptimedbcluster/test_cluster_enable_monitoring.go
+++ b/tests/e2e/greptimedbcluster/test_cluster_enable_monitoring.go
@@ -94,6 +94,25 @@ func TestClusterEnableMonitoring(ctx context.Context, h *helper.Helper) {
 	err = testMonitoringStandalone(ctx, monitoringAddr)
 	Expect(err).NotTo(HaveOccurred(), "failed to test monitoring")
 
+	// Disable monitoring.
+	By("Disable monitoring")
+	testCluster.Spec.Monitoring.Enabled = false
+	err = h.Update(ctx, testCluster)
+	Expect(err).NotTo(HaveOccurred(), "failed to update cluster")
+	By("Check the status of testCluster")
+	Eventually(func() error {
+		clusterPhase, err := h.GetPhase(ctx, testCluster.Namespace, testCluster.Name, new(greptimev1alpha1.GreptimeDBCluster))
+		if err != nil {
+			return err
+		}
+
+		if clusterPhase != greptimev1alpha1.PhaseRunning {
+			return fmt.Errorf("cluster is not running")
+		}
+
+		return nil
+	}, helper.DefaultTimeout, time.Second).ShouldNot(HaveOccurred())
+
 	By("Kill the port forwarding process")
 	h.KillPortForwardProcess()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced functionality to remove monitoring resources when monitoring is disabled in the cluster specification.
  - Enhanced monitoring checks across various components for improved clarity and efficiency.

- **Bug Fixes**
  - Updated logic to ensure that monitoring actions are only taken when explicitly enabled.

- **Tests**
  - Added functionality in tests to verify the behavior of disabling monitoring for a GreptimeDB cluster.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->