### PR TITLE
refactor: use file storage for monitoring standalone by default

### DIFF
--- a/apis/v1alpha1/constants.go
+++ b/apis/v1alpha1/constants.go
@@ -43,6 +43,9 @@ const (
 	// DefaultDataSize is the default size of the data when using the file storage.
 	DefaultDataSize = "10Gi"
 
+	// DefaultDataSizeForMonitoring is the default size of the data for monitoring.
+	DefaultDataSizeForMonitoring = "30Gi"
+
 	// DefaultDataHome is the default directory for the data.
 	DefaultDataHome = "/data/greptimedb"
 

--- a/apis/v1alpha1/defaulting.go
+++ b/apis/v1alpha1/defaulting.go
@@ -15,7 +15,6 @@
 package v1alpha1
 
 import (
-	"fmt"
 	"strings"
 
 	"dario.cat/mergo"
@@ -227,20 +226,15 @@ func (in *GreptimeDBCluster) defaultMonitoringStandaloneSpec() *GreptimeDBStanda
 
 	standalone.Spec.Version = getVersionFromImage(standalone.Spec.Base.MainContainer.Image)
 
-	if osp := in.GetObjectStorageProvider(); osp != nil {
-		standalone.Spec.ObjectStorageProvider = osp.DeepCopy()
-
-		if root := osp.GetS3Storage().GetRoot(); root != "" {
-			standalone.Spec.ObjectStorageProvider.S3.Root = fmt.Sprintf("%s/monitoring", root)
-		}
-
-		if root := osp.GetOSSStorage().GetRoot(); root != "" {
-			standalone.Spec.ObjectStorageProvider.OSS.Root = fmt.Sprintf("%s/monitoring", root)
-		}
-
-		if root := osp.GetGCSStorage().GetRoot(); root != "" {
-			standalone.Spec.ObjectStorageProvider.GCS.Root = fmt.Sprintf("%s/monitoring", root)
-		}
+	// For better performance and easy management, the monitoring standalone use file storage by default.
+	standalone.Spec.DatanodeStorage = &DatanodeStorageSpec{
+		DataHome: DefaultDataHome,
+		FileStorage: &FileStorage{
+			Name:                DefaultDatanodeFileStorageName,
+			StorageSize:         DefaultDataSizeForMonitoring,
+			MountPath:           DefaultDataHome,
+			StorageRetainPolicy: DefaultStorageRetainPolicyType,
+		},
 	}
 
 	return &standalone.Spec

--- a/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test03/expect.yaml
+++ b/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test03/expect.yaml
@@ -81,7 +81,7 @@ spec:
           mountPath: /data/greptimedb
           name: datanode
           storageRetainPolicy: Retain
-          storageSize: 10Gi
+          storageSize: 30Gi
       httpPort: 4000
       logging:
         format: text
@@ -90,13 +90,6 @@ spec:
         onlyLogToStdout: false
         persistentWithData: false
       mysqlPort: 4002
-      objectStorage:
-        s3:
-          bucket: greptimedb
-          endpoint: s3.amazonaws.com
-          region: us-west-2
-          root: /greptimedb/monitoring
-          secretName: s3-credentials
       postgreSQLPort: 4003
       rpcPort: 4001
       service:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new default data size for monitoring set to "30Gi".
	- Updated configurations for file storage in monitoring, emphasizing performance improvements.

- **Bug Fixes**
	- Streamlined the logging configuration to use JSON format when monitoring is enabled.

- **Documentation**
	- Updated configuration expectations for `GreptimeDBCluster`, reflecting changes in storage size and removal of object storage settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->