### PR TITLE
refactor: use no cache client to avoid watch permission

### DIFF
--- a/cmd/operator/app/command.go
+++ b/cmd/operator/app/command.go
@@ -112,10 +112,14 @@ func NewOperatorCommand() *cobra.Command {
 			}
 
 			if o.EnableAPIServer {
-				server := apiserver.NewServer(mgr.GetClient(), &apiserver.Options{
+				server, err := apiserver.NewServer(mgr, &apiserver.Options{
 					Port:             o.APIServerPort,
 					EnablePodMetrics: o.EnablePodMetrics,
 				})
+				if err != nil {
+					setupLog.Error(err, "unable to create API server")
+					os.Exit(1)
+				}
 
 				go func() {
 					if err := server.Run(); err != nil {

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -40,7 +40,10 @@ const (
 
 func TestHTTPGetService(t *testing.T) {
 	// Start the HTTP service.
-	svc := NewServer(&FakeClient{}, &Options{Port: TestPort})
+	svc := &Server{
+		Client: &FakeClient{},
+		port:   TestPort,
+	}
 	go func() {
 		if err := svc.Run(); err != nil {
 			t.Errorf("failed to start HTTP service: %v", err)


### PR DESCRIPTION
Reference: https://github.com/kubernetes-sigs/controller-runtime/issues/1156.