### PR TITLE
ci: bump go version to 1.23

### DIFF
--- a/.github/workflows/dev-build.yaml
+++ b/.github/workflows/dev-build.yaml
@@ -26,7 +26,7 @@ on:
         required: false
 
 env:
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.23"
 
   # The source code will check out in the following path: '${WORKING_DIR}/dev/greptimedb-operator'.
   CHECKOUT_SOURCE_PATH: dev/greptimedb-operator

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -39,7 +39,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.23"
 
 jobs:
   build:

--- a/.github/workflows/pr-title-checker.yaml
+++ b/.github/workflows/pr-title-checker.yaml
@@ -27,7 +27,7 @@ jobs:
   check-pr-title:
     runs-on: ubuntu-22.04
     steps:
-      - uses: thehanimo/pr-title-checker@v1.4.1
+      - uses: thehanimo/pr-title-checker@v1.4.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           pass_on_octokit_error: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ on:
       - "v*.*.*"
 
 env:
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.23"
 
 jobs:
   docker:
@@ -111,6 +111,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           name: "Release ${{ github.ref_name }}"
+          generate_release_notes: true
           files: |
             greptimedbclusters.yaml
             greptimedbstandalones.yaml

--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ CRD_REF_DOCS ?= $(LOCALBIN)/crd-ref-docs
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
 CRD_REF_DOCS_VERSION ?= v0.1.0
-GOLANGCI_LINT_VERSION ?= v1.55.2
+GOLANGCI_LINT_VERSION ?= v1.60.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.


### PR DESCRIPTION
## What's changed

1. Bump Go version to `1.23`;
2. Bump `pr-title-checker` version;
3. Generate release note automatically;