### PR TITLE
feat: Add label for the greptimedb services and controllers

### DIFF
--- a/controllers/greptimedbcluster/deployers/datanode.go
+++ b/controllers/greptimedbcluster/deployers/datanode.go
@@ -324,6 +324,9 @@ func (b *datanodeBuilder) BuildService() deployer.Builder {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: b.Cluster.Namespace,
 			Name:      common.ResourceName(b.Cluster.Name, b.ComponentKind),
+			Labels: map[string]string{
+				constant.GreptimeDBComponentName: common.ResourceName(b.Cluster.Name, b.ComponentKind),
+			},
 		},
 		Spec: corev1.ServiceSpec{
 			ClusterIP: corev1.ClusterIPNone,
@@ -376,6 +379,9 @@ func (b *datanodeBuilder) BuildStatefulSet() deployer.Builder {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.ResourceName(b.Cluster.Name, b.ComponentKind),
 			Namespace: b.Cluster.Namespace,
+			Labels: map[string]string{
+				constant.GreptimeDBComponentName: common.ResourceName(b.Cluster.Name, b.ComponentKind),
+			},
 		},
 		Spec: appsv1.StatefulSetSpec{
 			PodManagementPolicy: appsv1.ParallelPodManagement,

--- a/controllers/greptimedbcluster/deployers/flownode.go
+++ b/controllers/greptimedbcluster/deployers/flownode.go
@@ -130,6 +130,9 @@ func (b *flownodeBuilder) BuildService() deployer.Builder {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: b.Cluster.Namespace,
 			Name:      common.ResourceName(b.Cluster.Name, b.ComponentKind),
+			Labels: map[string]string{
+				constant.GreptimeDBComponentName: common.ResourceName(b.Cluster.Name, b.ComponentKind),
+			},
 		},
 		Spec: corev1.ServiceSpec{
 			ClusterIP: corev1.ClusterIPNone,
@@ -182,6 +185,9 @@ func (b *flownodeBuilder) BuildStatefulSet() deployer.Builder {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.ResourceName(b.Cluster.Name, b.ComponentKind),
 			Namespace: b.Cluster.Namespace,
+			Labels: map[string]string{
+				constant.GreptimeDBComponentName: common.ResourceName(b.Cluster.Name, b.ComponentKind),
+			},
 		},
 		Spec: appsv1.StatefulSetSpec{
 			PodManagementPolicy: appsv1.ParallelPodManagement,

--- a/controllers/greptimedbcluster/deployers/frontend.go
+++ b/controllers/greptimedbcluster/deployers/frontend.go
@@ -127,7 +127,9 @@ func (b *frontendBuilder) BuildService() deployer.Builder {
 			Namespace:   b.Cluster.Namespace,
 			Name:        common.ResourceName(b.Cluster.Name, b.ComponentKind),
 			Annotations: b.Cluster.Spec.Frontend.Service.Annotations,
-			Labels:      b.Cluster.Spec.Frontend.Service.Labels,
+			Labels: util.MergeStringMap(b.Cluster.Spec.Frontend.Service.Labels, map[string]string{
+				constant.GreptimeDBComponentName: common.ResourceName(b.Cluster.Name, b.ComponentKind),
+			}),
 		},
 		Spec: corev1.ServiceSpec{
 			Type: b.Cluster.Spec.Frontend.Service.Type,
@@ -161,6 +163,9 @@ func (b *frontendBuilder) BuildDeployment() deployer.Builder {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.ResourceName(b.Cluster.Name, b.ComponentKind),
 			Namespace: b.Cluster.Namespace,
+			Labels: map[string]string{
+				constant.GreptimeDBComponentName: common.ResourceName(b.Cluster.Name, b.ComponentKind),
+			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: b.Cluster.Spec.Frontend.Replicas,

--- a/controllers/greptimedbcluster/deployers/meta.go
+++ b/controllers/greptimedbcluster/deployers/meta.go
@@ -206,6 +206,9 @@ func (b *metaBuilder) BuildService() deployer.Builder {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: b.Cluster.Namespace,
 			Name:      common.ResourceName(b.Cluster.Name, b.ComponentKind),
+			Labels: map[string]string{
+				constant.GreptimeDBComponentName: common.ResourceName(b.Cluster.Name, b.ComponentKind),
+			},
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeClusterIP,
@@ -238,6 +241,9 @@ func (b *metaBuilder) BuildDeployment() deployer.Builder {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.ResourceName(b.Cluster.Name, b.ComponentKind),
 			Namespace: b.Cluster.Namespace,
+			Labels: map[string]string{
+				constant.GreptimeDBComponentName: common.ResourceName(b.Cluster.Name, b.ComponentKind),
+			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: b.Cluster.Spec.Meta.Replicas,

--- a/controllers/greptimedbstandalone/deployer.go
+++ b/controllers/greptimedbstandalone/deployer.go
@@ -190,7 +190,9 @@ func (b *standaloneBuilder) BuildService() deployer.Builder {
 			Namespace:   b.standalone.Namespace,
 			Name:        common.ResourceName(b.standalone.Name, v1alpha1.StandaloneKind),
 			Annotations: b.standalone.Spec.Service.Annotations,
-			Labels:      b.standalone.Spec.Service.Labels,
+			Labels: util.MergeStringMap(b.standalone.Spec.Service.Labels, map[string]string{
+				constant.GreptimeDBComponentName: common.ResourceName(b.standalone.Name, v1alpha1.StandaloneKind),
+			}),
 		},
 		Spec: corev1.ServiceSpec{
 			Type: b.standalone.Spec.Service.Type,
@@ -242,6 +244,9 @@ func (b *standaloneBuilder) BuildStatefulSet() deployer.Builder {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.ResourceName(b.standalone.Name, v1alpha1.StandaloneKind),
 			Namespace: b.standalone.Namespace,
+			Labels: map[string]string{
+				constant.GreptimeDBComponentName: common.ResourceName(b.standalone.Name, v1alpha1.StandaloneKind),
+			},
 		},
 		Spec: appsv1.StatefulSetSpec{
 			// Always set replicas to 1 for standalone mode.


### PR DESCRIPTION
Close: https://github.com/GreptimeTeam/greptimedb-operator/issues/222

```
kubectl get svc --show-labels
NAME               TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                               AGE     LABELS
basic-datanode     ClusterIP   None            <none>        4001/TCP,4000/TCP                     3m30s   app.greptime.io/component=basic-datanode
basic-flownode     ClusterIP   None            <none>        4001/TCP                              116s    app.greptime.io/component=basic-flownode
basic-frontend     ClusterIP   10.96.203.28    <none>        4001/TCP,4000/TCP,4002/TCP,4003/TCP   3m24s   app.greptime.io/component=basic-frontend
basic-meta         ClusterIP   10.96.210.136   <none>        3002/TCP,4000/TCP                     3m36s   app.greptime.io/component=basic-meta
basic-standalone   ClusterIP   10.96.195.101   <none>        4001/TCP,4000/TCP,4002/TCP,4003/TCP   22s     app.greptime.io/component=basic-standalone
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Kubernetes resource management by adding labels to Service and StatefulSet objects for better identification and tracking.
	- Improved metadata for deployment and service objects to facilitate service discovery.

- **Bug Fixes**
	- No bug fixes were included in this release.

- **Documentation**
	- No changes to documentation were made.

- **Refactor**
	- Improved labeling mechanisms across various components without altering existing logic or control flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->