### PR TITLE
refactor: Add the `IsObjectLabelsEqual` function to check the object labels are equal

### DIFF
--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -118,13 +118,15 @@ func (d *DefaultDeployer) Apply(ctx context.Context, _ client.Object, objects []
 		}
 
 		if oldObject != nil {
-			equal, err := k8sutils.IsObjectSpecEqual(oldObject, newObject, LastAppliedResourceSpec)
+			specEqual, err := k8sutils.IsObjectSpecEqual(oldObject, newObject, LastAppliedResourceSpec)
 			if err != nil {
 				return err
 			}
 
-			// If the spec is not equal, update the object.
-			if !equal {
+			labelsEqual := k8sutils.IsObjectLabelsEqual(oldObject.GetLabels(), newObject.GetLabels())
+
+			// If the spec or labels is not equal, update the object.
+			if !specEqual || !labelsEqual {
 				newObject.SetResourceVersion(oldObject.GetResourceVersion())
 				if err := d.Client.Patch(ctx, newObject, client.MergeFrom(oldObject)); err != nil {
 					return err

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -50,30 +50,35 @@ func CreateObjectIfNotExist(ctx context.Context, c client.Client, source, newObj
 }
 
 // IsObjectSpecEqual checks if the spec of the object is equal to other one.
-func IsObjectSpecEqual(objectA, objectB client.Object, annotationKey string) (bool, error) {
-	objectASpecStr, ok := objectA.GetAnnotations()[annotationKey]
+func IsObjectSpecEqual(oldObject, newObject client.Object, annotationKey string) (bool, error) {
+	oldObjectSpecStr, ok := oldObject.GetAnnotations()[annotationKey]
 	if !ok {
 		return false, fmt.Errorf("the objectA object '%s' does not have annotation '%s'",
-			client.ObjectKeyFromObject(objectA), annotationKey)
+			client.ObjectKeyFromObject(oldObject), annotationKey)
 	}
 
-	objectBSpecStr, ok := objectB.GetAnnotations()[annotationKey]
+	newObjectSpecStr, ok := newObject.GetAnnotations()[annotationKey]
 	if !ok {
 		return false, fmt.Errorf("the objectB object '%s' does not have annotation '%s'",
-			client.ObjectKeyFromObject(objectB), annotationKey)
+			client.ObjectKeyFromObject(newObject), annotationKey)
 	}
 
-	var objectASpec, objectBSpec interface{}
+	var oldObjectSpec, newObjectSpec interface{}
 
-	if err := json.Unmarshal([]byte(objectASpecStr), &objectASpec); err != nil {
+	if err := json.Unmarshal([]byte(oldObjectSpecStr), &oldObjectSpec); err != nil {
 		return false, err
 	}
 
-	if err := json.Unmarshal([]byte(objectBSpecStr), &objectBSpec); err != nil {
+	if err := json.Unmarshal([]byte(newObjectSpecStr), &newObjectSpec); err != nil {
 		return false, err
 	}
 
-	return reflect.DeepEqual(objectASpec, objectBSpec), nil
+	return reflect.DeepEqual(oldObjectSpec, newObjectSpec), nil
+}
+
+// IsObjectLabelsEqual checks if the labels of the object is equal to other one.
+func IsObjectLabelsEqual(oldObjectLabels, newObjectLabels map[string]string) bool {
+	return reflect.DeepEqual(oldObjectLabels, newObjectLabels)
 }
 
 // IsDeploymentReady checks if the deployment is ready.

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -53,13 +53,13 @@ func CreateObjectIfNotExist(ctx context.Context, c client.Client, source, newObj
 func IsObjectSpecEqual(oldObject, newObject client.Object, annotationKey string) (bool, error) {
 	oldObjectSpecStr, ok := oldObject.GetAnnotations()[annotationKey]
 	if !ok {
-		return false, fmt.Errorf("the objectA object '%s' does not have annotation '%s'",
+		return false, fmt.Errorf("the old object '%s' does not have annotation '%s'",
 			client.ObjectKeyFromObject(oldObject), annotationKey)
 	}
 
 	newObjectSpecStr, ok := newObject.GetAnnotations()[annotationKey]
 	if !ok {
-		return false, fmt.Errorf("the objectB object '%s' does not have annotation '%s'",
+		return false, fmt.Errorf("the new object '%s' does not have annotation '%s'",
 			client.ObjectKeyFromObject(newObject), annotationKey)
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced update logic for Kubernetes objects to consider both specifications and labels.
	- Introduced a new function for label comparison to streamline the update process.

- **Bug Fixes**
	- Improved error messages for missing annotations to reflect updated parameter names.

- **Documentation**
	- Updated comments to clarify the conditions for object updates based on specifications and labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->