### PR TITLE
fix: incorrect api path

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -10,7 +10,7 @@ resources:
   controller: true
   domain: greptime.io
   kind: GreptimeDBCluster
-  path: github.com/GreptimeTeam/greptimedb-operator/api/v1alpha1
+  path: github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -18,6 +18,6 @@ resources:
   controller: true
   domain: greptime.io
   kind: GreptimeDBStandalone
-  path: github.com/greptime/greptimedb-operator/api/v1alpha1
+  path: github.com/greptime/greptimedb-operator/apis/v1alpha1
   version: v1alpha1
 version: "3"


### PR DESCRIPTION
The path is apis: https://github.com/GreptimeTeam/greptimedb-operator

![image](https://github.com/user-attachments/assets/1382425b-647e-4c56-ad50-b484b947c793)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated API resource paths for `GreptimeDBCluster` and `GreptimeDBStandalone` to reflect a new directory structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->