### PR TITLE
chore: add policy to delete configmap

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -42,6 +42,7 @@ rules:
   - configmaps
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/controllers/greptimedbcluster/controller.go
+++ b/controllers/greptimedbcluster/controller.go
@@ -100,7 +100,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;patch;create;
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;patch;watch;create;update;delete;
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;patch;watch;
-// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;patch;create;update;
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;patch;create;update;delete;
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;patch;watch;create;
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;patch;watch;create;update;delete;
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete

--- a/manifests/bundle.yaml
+++ b/manifests/bundle.yaml
@@ -25468,6 +25468,7 @@ rules:
   - configmaps
   verbs:
   - create
+  - delete
   - get
   - list
   - patch


### PR DESCRIPTION
Fixed to:
```
E0306 17:18:24.865067       1 controller.go:329] "Reconciler error" err="configmaps \"vector-config\" is forbidden: User \"system:serviceaccount:greptimedb-admin:greptimedb-operator\" cannot delete resource \"configmaps\" in API group \"\" in the namespace \"default\"" controller="greptimedbcluster" controllerGroup="greptime.io" controllerKind="GreptimeDBCluster" GreptimeDBCluster="default/e2e-cluster-enable-monitoring" namespace="default" name="e2e-cluster-enable-monitoring" reconcileID="9a98b77c-1567-43ba-bbda-881690e2fba3"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded system configuration management now supports removal of outdated configuration data, enhancing administrative resource control and operational flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->