### PR TITLE
chore: add virtual_host_style for s3 storage

### DIFF
--- a/apis/v1alpha1/common.go
+++ b/apis/v1alpha1/common.go
@@ -727,6 +727,12 @@ type S3Storage struct {
 	// The endpoint of the bucket.
 	// +optional
 	Endpoint string `json:"endpoint,omitempty"`
+
+	// Enable virtual host style so that opendal will send API requests in virtual host style instead of path style.
+	// By default, opendal will send API to 'https://s3.us-east-1.amazonaws.com/bucket_name'.
+	// Enabled, opendal will send API to 'https://bucket_name.s3.us-east-1.amazonaws.com'.
+	// +optional
+	EnableVirtualHostStyle bool `json:"enableVirtualHostStyle,omitempty"`
 }
 
 func (in *S3Storage) GetSecretName() string {

--- a/apis/v1alpha1/common.go
+++ b/apis/v1alpha1/common.go
@@ -728,9 +728,9 @@ type S3Storage struct {
 	// +optional
 	Endpoint string `json:"endpoint,omitempty"`
 
-	// Enable virtual host style so that opendal will send API requests in virtual host style instead of path style.
-	// By default, opendal will send API to 'https://s3.us-east-1.amazonaws.com/${BUCKET_NAME}'.
-	// Enabled, opendal will send API to 'https://${BUCKET_NAME}.s3.us-east-1.amazonaws.com'.
+	// Enable virtual host style so that OpenDAL will send API requests in virtual host style instead of path style.
+	// By default, OpenDAL will send API to 'https://s3.us-east-1.amazonaws.com/${BUCKET_NAME}'.
+	// If EnableVirtualHostStyle is true, OpenDAL will send API to 'https://${BUCKET_NAME}.s3.us-east-1.amazonaws.com'.
 	// +optional
 	EnableVirtualHostStyle bool `json:"enableVirtualHostStyle,omitempty"`
 }

--- a/apis/v1alpha1/common.go
+++ b/apis/v1alpha1/common.go
@@ -729,8 +729,8 @@ type S3Storage struct {
 	Endpoint string `json:"endpoint,omitempty"`
 
 	// Enable virtual host style so that opendal will send API requests in virtual host style instead of path style.
-	// By default, opendal will send API to 'https://s3.us-east-1.amazonaws.com/bucket_name'.
-	// Enabled, opendal will send API to 'https://bucket_name.s3.us-east-1.amazonaws.com'.
+	// By default, opendal will send API to 'https://s3.us-east-1.amazonaws.com/${BUCKET_NAME}'.
+	// Enabled, opendal will send API to 'https://${BUCKET_NAME}.s3.us-east-1.amazonaws.com'.
 	// +optional
 	EnableVirtualHostStyle bool `json:"enableVirtualHostStyle,omitempty"`
 }

--- a/config/crd/resources/greptime.io_greptimedbclusters.yaml
+++ b/config/crd/resources/greptime.io_greptimedbclusters.yaml
@@ -21619,6 +21619,8 @@ spec:
                             properties:
                               bucket:
                                 type: string
+                              enableVirtualHostStyle:
+                                type: boolean
                               endpoint:
                                 type: string
                               region:
@@ -21859,6 +21861,8 @@ spec:
                     properties:
                       bucket:
                         type: string
+                      enableVirtualHostStyle:
+                        type: boolean
                       endpoint:
                         type: string
                       region:

--- a/config/crd/resources/greptime.io_greptimedbstandalones.yaml
+++ b/config/crd/resources/greptime.io_greptimedbstandalones.yaml
@@ -3189,6 +3189,8 @@ spec:
                     properties:
                       bucket:
                         type: string
+                      enableVirtualHostStyle:
+                        type: boolean
                       endpoint:
                         type: string
                       region:

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -835,7 +835,7 @@ _Appears in:_
 | `secretName` _string_ | The secret of storing the credentials of access key id and secret access key.<br />The secret should contain keys named `access-key-id` and `secret-access-key`.<br />The secret must be the same namespace with the GreptimeDBCluster resource. |  |  |
 | `root` _string_ | The S3 directory path. |  |  |
 | `endpoint` _string_ | The endpoint of the bucket. |  |  |
-| `enableVirtualHostStyle` _boolean_ | Enable virtual host style so that opendal will send API requests in virtual host style instead of path style.<br />By default, opendal will send API to 'https://s3.us-east-1.amazonaws.com/$\{BUCKET_NAME\}'.<br />Enabled, opendal will send API to 'https://$\{BUCKET_NAME\}.s3.us-east-1.amazonaws.com'. |  |  |
+| `enableVirtualHostStyle` _boolean_ | Enable virtual host style so that OpenDAL will send API requests in virtual host style instead of path style.<br />By default, OpenDAL will send API to 'https://s3.us-east-1.amazonaws.com/$\{BUCKET_NAME\}'.<br />If EnableVirtualHostStyle is true, OpenDAL will send API to 'https://$\{BUCKET_NAME\}.s3.us-east-1.amazonaws.com'. |  |  |
 
 
 #### ServiceSpec

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -835,6 +835,7 @@ _Appears in:_
 | `secretName` _string_ | The secret of storing the credentials of access key id and secret access key.<br />The secret should contain keys named `access-key-id` and `secret-access-key`.<br />The secret must be the same namespace with the GreptimeDBCluster resource. |  |  |
 | `root` _string_ | The S3 directory path. |  |  |
 | `endpoint` _string_ | The endpoint of the bucket. |  |  |
+| `enableVirtualHostStyle` _boolean_ | Enable virtual host style so that opendal will send API requests in virtual host style instead of path style.<br />By default, opendal will send API to 'https://s3.us-east-1.amazonaws.com/$\{BUCKET_NAME\}'.<br />Enabled, opendal will send API to 'https://$\{BUCKET_NAME\}.s3.us-east-1.amazonaws.com'. |  |  |
 
 
 #### ServiceSpec

--- a/manifests/bundle.yaml
+++ b/manifests/bundle.yaml
@@ -21625,6 +21625,8 @@ spec:
                             properties:
                               bucket:
                                 type: string
+                              enableVirtualHostStyle:
+                                type: boolean
                               endpoint:
                                 type: string
                               region:
@@ -21865,6 +21867,8 @@ spec:
                     properties:
                       bucket:
                         type: string
+                      enableVirtualHostStyle:
+                        type: boolean
                       endpoint:
                         type: string
                       region:
@@ -25230,6 +25234,8 @@ spec:
                     properties:
                       bucket:
                         type: string
+                      enableVirtualHostStyle:
+                        type: boolean
                       endpoint:
                         type: string
                       region:

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -21618,6 +21618,8 @@ spec:
                             properties:
                               bucket:
                                 type: string
+                              enableVirtualHostStyle:
+                                type: boolean
                               endpoint:
                                 type: string
                               region:
@@ -21858,6 +21860,8 @@ spec:
                     properties:
                       bucket:
                         type: string
+                      enableVirtualHostStyle:
+                        type: boolean
                       endpoint:
                         type: string
                       region:
@@ -25223,6 +25227,8 @@ spec:
                     properties:
                       bucket:
                         type: string
+                      enableVirtualHostStyle:
+                        type: boolean
                       endpoint:
                         type: string
                       region:

--- a/pkg/dbconfig/common.go
+++ b/pkg/dbconfig/common.go
@@ -43,6 +43,7 @@ type StorageConfig struct {
 	Container              *string `tomlmapping:"storage.container"`
 	AccountName            *string `tomlmapping:"storage.account_name"`
 	AccountKey             *string `tomlmapping:"storage.account_key"`
+	EnableVirtualHostStyle *bool   `tomlmapping:"storage.enable_virtual_host_style"`
 }
 
 // ConfigureObjectStorage configures the storage config by the given object storage provider accessor.
@@ -86,6 +87,10 @@ func (c *StorageConfig) configureS3(namespace string, s3 *v1alpha1.S3Storage) er
 		}
 		c.StorageAccessKeyID = ptr.To(string(data[0]))
 		c.StorageSecretAccessKey = ptr.To(string(data[1]))
+	}
+
+	if s3.EnableVirtualHostStyle {
+		c.EnableVirtualHostStyle = ptr.To(s3.EnableVirtualHostStyle)
 	}
 
 	return nil

--- a/pkg/dbconfig/common.go
+++ b/pkg/dbconfig/common.go
@@ -89,9 +89,7 @@ func (c *StorageConfig) configureS3(namespace string, s3 *v1alpha1.S3Storage) er
 		c.StorageSecretAccessKey = ptr.To(string(data[1]))
 	}
 
-	if s3.EnableVirtualHostStyle {
-		c.EnableVirtualHostStyle = ptr.To(s3.EnableVirtualHostStyle)
-	}
+	c.EnableVirtualHostStyle = ptr.To(s3.EnableVirtualHostStyle)
 
 	return nil
 }

--- a/pkg/dbconfig/common.go
+++ b/pkg/dbconfig/common.go
@@ -89,7 +89,9 @@ func (c *StorageConfig) configureS3(namespace string, s3 *v1alpha1.S3Storage) er
 		c.StorageSecretAccessKey = ptr.To(string(data[1]))
 	}
 
-	c.EnableVirtualHostStyle = ptr.To(s3.EnableVirtualHostStyle)
+	if s3.EnableVirtualHostStyle {
+	    c.EnableVirtualHostStyle = ptr.To(s3.EnableVirtualHostStyle)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Related PR: https://github.com/GreptimeTeam/greptimedb/pull/5696

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new setting to enable S3 API requests to use a virtual host format. When activated, the bucket name is included within the request hostname, offering a more flexible configuration for storage access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->