### PR TITLE
feat: Add ValidatingWebhook to verify CR resource validity

### DIFF
--- a/apis/v1alpha1/greptimedbcluster_webhook.go
+++ b/apis/v1alpha1/greptimedbcluster_webhook.go
@@ -31,9 +31,7 @@ func (r *GreptimeDBCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-
-// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+// TODO(liyang): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 //+kubebuilder:webhook:path=/validate-greptime-io-v1alpha1-greptimedbcluster,mutating=false,failurePolicy=fail,sideEffects=None,groups=greptime.io,resources=greptimedbclusters,verbs=create;update,versions=v1alpha1,name=vgreptimedbcluster.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Validator = &GreptimeDBCluster{}
@@ -42,22 +40,26 @@ var _ webhook.Validator = &GreptimeDBCluster{}
 func (r *GreptimeDBCluster) ValidateCreate() (admission.Warnings, error) {
 	greptimedbclusterlog.Info("validate create", "name", r.Name)
 
-	// TODO(user): fill in your validation logic upon object creation.
+	if err := r.Validate(); err != nil {
+		return nil, err
+	}
+
 	return nil, nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *GreptimeDBCluster) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
+func (r *GreptimeDBCluster) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) {
 	greptimedbclusterlog.Info("validate update", "name", r.Name)
 
-	// TODO(user): fill in your validation logic upon object update.
+	if err := r.Validate(); err != nil {
+		return nil, err
+	}
+
 	return nil, nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *GreptimeDBCluster) ValidateDelete() (admission.Warnings, error) {
-	greptimedbclusterlog.Info("validate delete", "name", r.Name)
-
-	// TODO(user): fill in your validation logic upon object deletion.
+	// FIXME(liyang): Unnecessary validation when object deletion.
 	return nil, nil
 }

--- a/apis/v1alpha1/greptimedbstandalone_webhook.go
+++ b/apis/v1alpha1/greptimedbstandalone_webhook.go
@@ -31,9 +31,7 @@ func (r *GreptimeDBStandalone) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-
-// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+// TODO(liyang): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 //+kubebuilder:webhook:path=/validate-greptime-io-v1alpha1-greptimedbstandalone,mutating=false,failurePolicy=fail,sideEffects=None,groups=greptime.io,resources=greptimedbstandalones,verbs=create;update,versions=v1alpha1,name=vgreptimedbstandalone.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Validator = &GreptimeDBStandalone{}
@@ -42,22 +40,26 @@ var _ webhook.Validator = &GreptimeDBStandalone{}
 func (r *GreptimeDBStandalone) ValidateCreate() (admission.Warnings, error) {
 	greptimedbstandalonelog.Info("validate create", "name", r.Name)
 
-	// TODO(user): fill in your validation logic upon object creation.
+	if err := r.Validate(); err != nil {
+		return nil, err
+	}
+
 	return nil, nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *GreptimeDBStandalone) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
+func (r *GreptimeDBStandalone) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) {
 	greptimedbstandalonelog.Info("validate update", "name", r.Name)
 
-	// TODO(user): fill in your validation logic upon object update.
+	if err := r.Validate(); err != nil {
+		return nil, err
+	}
+
 	return nil, nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *GreptimeDBStandalone) ValidateDelete() (admission.Warnings, error) {
-	greptimedbstandalonelog.Info("validate delete", "name", r.Name)
-
-	// TODO(user): fill in your validation logic upon object deletion.
+	// FIXME(liyang): Unnecessary validation when object deletion.
 	return nil, nil
 }

--- a/cmd/operator/app/options/options.go
+++ b/cmd/operator/app/options/options.go
@@ -23,7 +23,7 @@ const (
 	defaultHealthProbeAddr         = ":9494"
 	defaultAPIServerPort           = 8081
 	defaultAdmissionWebhookPort    = 8082
-	defaultAdmissionWebhookCertDir = "/etc/greptimedb/admission-webhook-tls"
+	defaultAdmissionWebhookCertDir = "/etc/webhook-tls"
 )
 
 type Options struct {
@@ -43,6 +43,7 @@ func NewDefaultOptions() *Options {
 		MetricsAddr:             defaultMetricsAddr,
 		HealthProbeAddr:         defaultHealthProbeAddr,
 		APIServerPort:           defaultAPIServerPort,
+		EnableLeaderElection:    true,
 		EnableAPIServer:         false,
 		EnablePodMetrics:        false,
 		EnableAdmissionWebhook:  false,

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Greptime Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,17 +1,3 @@
-# Copyright 2024 Greptime Team
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/controllers/greptimedbcluster/controller.go
+++ b/controllers/greptimedbcluster/controller.go
@@ -52,14 +52,18 @@ var (
 type Reconciler struct {
 	client.Client
 
+	EnableAdmissionWebhook bool
+
 	Scheme           *runtime.Scheme
 	Deployers        []deployer.Deployer
 	Recorder         record.EventRecorder
 	MetricsCollector *metrics.MetricsCollector
 }
 
-func Setup(mgr ctrl.Manager, _ *options.Options) error {
+func Setup(mgr ctrl.Manager, o *options.Options) error {
 	reconciler := &Reconciler{
+		EnableAdmissionWebhook: o.EnableAdmissionWebhook,
+
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("greptimedbcluster-controller"),
@@ -139,6 +143,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err = r.addFinalizer(ctx, cluster); err != nil {
 		r.Recorder.Event(cluster, corev1.EventTypeWarning, "AddFinalizerFailed", fmt.Sprintf("Add finalizer failed: %v", err))
 		return ctrl.Result{}, err
+	}
+
+	if !r.EnableAdmissionWebhook {
+		if err = cluster.Validate(); err != nil {
+			r.Recorder.Event(cluster, corev1.EventTypeWarning, "InvalidCluster", fmt.Sprintf("Invalid cluster: %v", err))
+			return ctrl.Result{}, err
+		}
 	}
 
 	if err = cluster.Check(ctx, r.Client); err != nil {

--- a/controllers/greptimedbcluster/controller.go
+++ b/controllers/greptimedbcluster/controller.go
@@ -141,11 +141,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	if err = cluster.Validate(); err != nil {
-		r.Recorder.Event(cluster, corev1.EventTypeWarning, "InvalidCluster", fmt.Sprintf("Invalid cluster: %v", err))
-		return ctrl.Result{}, err
-	}
-
 	if err = cluster.Check(ctx, r.Client); err != nil {
 		r.Recorder.Event(cluster, corev1.EventTypeWarning, "InvalidCluster", fmt.Sprintf("Invalid cluster: %v", err))
 		return ctrl.Result{}, err

--- a/controllers/greptimedbstandalone/controller.go
+++ b/controllers/greptimedbstandalone/controller.go
@@ -109,11 +109,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	if err = standalone.Validate(); err != nil {
-		r.Recorder.Event(standalone, corev1.EventTypeWarning, "InvalidStandalone", fmt.Sprintf("Invalid standalone: %v", err))
-		return ctrl.Result{}, err
-	}
-
 	if err = standalone.Check(ctx, r.Client); err != nil {
 		r.Recorder.Event(standalone, corev1.EventTypeWarning, "InvalidStandalone", fmt.Sprintf("Invalid standalone: %v", err))
 		return ctrl.Result{}, err

--- a/controllers/greptimedbstandalone/controller.go
+++ b/controllers/greptimedbstandalone/controller.go
@@ -49,13 +49,17 @@ var (
 type Reconciler struct {
 	client.Client
 
+	EnableAdmissionWebhook bool
+
 	Scheme   *runtime.Scheme
 	Deployer deployer.Deployer
 	Recorder record.EventRecorder
 }
 
-func Setup(mgr ctrl.Manager, _ *options.Options) error {
+func Setup(mgr ctrl.Manager, o *options.Options) error {
 	reconciler := &Reconciler{
+		EnableAdmissionWebhook: o.EnableAdmissionWebhook,
+
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("greptimedbstandalone-controller"),
@@ -107,6 +111,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err = r.addFinalizer(ctx, standalone); err != nil {
 		r.Recorder.Event(standalone, corev1.EventTypeWarning, "AddFinalizerFailed", fmt.Sprintf("Add finalizer failed: %v", err))
 		return ctrl.Result{}, err
+	}
+
+	if !r.EnableAdmissionWebhook {
+		if err = standalone.Validate(); err != nil {
+			r.Recorder.Event(standalone, corev1.EventTypeWarning, "InvalidStandalone", fmt.Sprintf("Invalid standalone: %v", err))
+			return ctrl.Result{}, err
+		}
 	}
 
 	if err = standalone.Check(ctx, r.Client); err != nil {


### PR DESCRIPTION
Move `Validate()` to admission webhook for verification.

### Deployment
Create secret:
```
apiVersion: v1
data:
  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURMVENDQWhXZ0F3SUJBZ0lSQUxMVWxhWERtOC8wWGdoOHpZdU5wOWd3RFFZSktvWklodmNOQVFFTEJRQXcKQURBZUZ3MHlOVEEwTURjeE1qQTROREphRncweU5UQTNNRFl4TWpBNE5ESmFNQUF3Z2dFaU1BMEdDU3FHU0liMwpEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUUMvQm04OXhQUVQ3SFY1ZW9Qb2dLamhJdTBzQS9tVm5qVmNBMVAzCmJZem03RVRPVTVUSTBqVW5qbk1saDlKaXpmMEpKVFY5dlZhWDNDUlZ2Z2ZWWmJZWDFEdC9XY2ZVMVB6YVZ0cWkKOTl5ODliTDNwR2p0SWJOWS9zOWJzblB2d3NKcHlXbjI5dUY1UU5acUZKbkFlMTZLeHhHcVJwbEgvUXZjNWhuVAp0ck9rSmdIblZKVlJ3cUNncDRlc2NMRGE2VEpJNE1yRGlxL1U2VnVXSmZnczlFbHFJeFpEZndJbjI2WHg4Z0xyCmMvRTB1MUhRTmxBTExZeEhQbHoxaUoyTmxvYVNZQ1pjQy83U24vdCs1bTd1c0FIUDR2eW1qRjJrSlhaZktZeTEKRFc3ZkIrTmlxRFZOYUl2SlFxWkRlNGMycFZUeFZvTzFYRm5GNnExMzd1Z0c2NmJ6QWdNQkFBR2pnYUV3Z1o0dwpEZ1lEVlIwUEFRSC9CQVFEQWdXZ01Bd0dBMVVkRXdFQi93UUNNQUF3ZmdZRFZSMFJBUUgvQkhRd2NvSXdaM0psCmNIUnBiV1ZrWWkxdmNHVnlZWFJ2Y2kxM1pXSm9iMjlyTG1keVpYQjBhVzFsWkdJdFlXUnRhVzR1YzNaamdqNW4KY21Wd2RHbHRaV1JpTFc5d1pYSmhkRzl5TFhkbFltaHZiMnN1WjNKbGNIUnBiV1ZrWWkxaFpHMXBiaTV6ZG1NdQpZMngxYzNSbGNpNXNiMk5oYkRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQUQ5NjU0VzIrNGNMdTkyZUU2VHJVCjkwVTN5ZW9aSkk2YWthU2RVNXhRcURlcEdUTFZEaURBMVNlNmVlWlB5YnZkQ3YzdWZUd2M3NFg3MmwxL0JtTHgKTitsVk9EQ0J6dzVkcVJiSlUzVE1maXFEMGF5Vnp4enhOaDNQUlMrMGRTQVZXelI2enhWeENPVWFURkRNWXRGVgo4cVIyR2dsYVFoWW4reGkxd3hyTm8yOTE2R1hJR2FxZWZlM3hWbWl3b2g2VXhaMWF4WVJSTFZoZU9seHE5RThzCnc3NUtLZkdGSE5DNTJBcUlkajF2RVBIM2xoejcrYVZBMWR4R0hES0NqQjNGaGtzYlhyNERReGdFeVcyanpIWkEKZWVPQWFNTkJtTytmclJkM2t1L1doRkMyQm5mRzhrWTd6ZUF6OGtrMXVRSnhCZ1ozYURwV0puSmRNaHhKY1VVRApGUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcFFJQkFBS0NBUUVBdndadlBjVDBFK3gxZVhxRDZJQ280U0x0TEFQNWxaNDFYQU5UOTIyTTV1eEV6bE9VCnlOSTFKNDV6SllmU1lzMzlDU1UxZmIxV2w5d2tWYjRIMVdXMkY5UTdmMW5IMU5UODJsYmFvdmZjdlBXeTk2Um8KN1NHeldQN1BXN0p6NzhMQ2FjbHA5dmJoZVVEV2FoU1p3SHRlaXNjUnFrYVpSLzBMM09ZWjA3YXpwQ1lCNTFTVgpVY0tnb0tlSHJIQ3cydWt5U09ES3c0cXYxT2xibGlYNExQUkphaU1XUTM4Q0o5dWw4ZklDNjNQeE5MdFIwRFpRCkN5Mk1SejVjOVlpZGpaYUdrbUFtWEF2KzBwLzdmdVp1N3JBQnorTDhwb3hkcENWMlh5bU10UTF1M3dmallxZzEKVFdpTHlVS21RM3VITnFWVThWYUR0VnhaeGVxdGQrN29CdXVtOHdJREFRQUJBb0lCQVFDcE1NdktTKzFhMEM1awpQKzBoT3dOWkZKUTRUZlQ3WGJzcEdoRitydHNEbFBTRVFtY2ZUMytnMzN5QkcwRnVIY0FtSDN5M044SEFrMHpqClhJS1hzWlNNbW45d0ZsYjEzUWR2WTBvVzJhMzY5eXRpUjQ1ZnFWK3VUVkhmaDdsRC9KNHhFQ0g0aVVXL0hYeEwKVEorNWFndWNveUMwVGY5cFVXajJhQjhyODBBOCs1ekxGNmFkSFlJbHZZSFdCYUZnVVZXVTlUSnJwbHMva0k3aApvaUJ5VGsvWFVoQjVWbDlBT0tUclJLOGE3RkhzZUdtTWRFQmMvTkxwRFRuSXZhUlNHVzFRcWY2M0Y5UlA5L3QyCitwL2JGQlBlb1orUjNnRmRkZ24yck8zY2ZGYmViYXdHUlNXK052eVhtYjBRSzZCMytEcElGWHdmaVI3cGJLZ3gKQytHbElFNHhBb0dCQU9jZ2pUUnQ3ZjNqaHBZL3AvRCs1Q1Ayc0lMSlRRelFJcE1JWk5wSUQwZkxkbjQwc2xQdgpBaW9ZNjZ5ekxjSFpVTUxYQ0RNSzQzTHg3aXlrQS9abXJnTGdqRjJZSWQzKzVtL0FCd09NenJBQU9DcVhaVFRjCkdmT1M1cWszbUhsYzRxdk9VV1RjeEJzZmlpOVFSL2JPcTVtang4NXUwZ3djUXJLSDNpeUhSeHovQW9HQkFOT1YKRnlsNXd6RWJQdlBjaXgwakxsODlaMkxab0t1Z3ZqZDJobm9sa3BZSlpScWZjZFd1eWtXbFJxNXRiZmlQWXJ3Swo4aGdwZDdGckhmeXhFTHBoeTY2NG1JRDRQcVpXSGtlTzVhdHBqZXF0ZjZBT3VQNVd6eERpdVRBaWY0Q2gxZHN6Cm4vK2tUU09mRUZkZEpyeHkrd1N5bmJHQk1SS0Nhazd3QXhuL2V0SU5Bb0dCQUl5VllTNU4yMS85NENSTnplSXAKdUMwajVSTjRUQlNLR1Mya0Ftdy9Qb1FsL3dvZkZZVTJNUFBZT3FuT1J2dk5LbkdKQ0NTNzc4TS80dVptVVQ2MApFQTRSOVc4TWxUVUowYktSYy9LMTJCWjMyN0lVYW12dm9SMWw4a1ZsV3FvZlZJUzZOd29KdW9MZytWVjBHSUhJCkRkcWpJMnF1UDdjOERWbTRpT3crMElPVEFvR0FlWkJSakh6dkR3bk9jNklsTTRxQkhDdFZlVS84cGw5bXFzc28KbklsMTNVcHNrbzFGaERZMjlTanVvVTB5UC90eUNRUm84RVR6QmphN05mSXQ0RWhNRklqdTVqcTdGQ3FxbndhVgpJcFUwK3I3UWN3L0NiaTlHTFRkMm14ZFhGbnJsT2xwQTlVcGJIN3BHVTB1cjg5NUVKd0RRNWFtS25rM2I4cHFuCnpZb2g4UWtDZ1lFQXhZZEZQWmhyOFpsV2NNZzJrdUpvN1RlT3czUXY2NDA4akpteks1Z2Q5Y1hIN3R1MmhUN0cKNGp0TWZnV0xwWitaN3lqbk0xbGRDTTc2WXdEaVFSVVV0MjZObTF0OEU2WlI2KzNuQTVkcmNEZmlQV25CejhqagpZNmhLZHZXUkszWnlIWWMxS1M1WUpCZ3RrQ1FTL0lHS2VSbEYwa3FINkxXSWJ2bi84T3NQMDFvPQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
kind: Secret
metadata:
  name: webhook-server-tls
  namespace: greptimedb-admin
type: kubernetes.io/tls
```

Create operator service:
```
apiVersion: v1
kind: Service
metadata:
  labels:
    app.kubernetes.io/name: service
    app.kubernetes.io/instance: greptimedb-operator
    app.kubernetes.io/component: webhook
    app.kubernetes.io/created-by: greptimedb-operator
    app.kubernetes.io/part-of: greptimedb-operator
    app.kubernetes.io/managed-by: kustomize
  name: greptimedb-operator-webhook
  namespace: greptimedb-admin
spec:
  ports:
    - port: 443
      protocol: TCP
      targetPort: 8082
  selector:
    control-plane: controller-manager
```

Create operator
```
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    control-plane: controller-manager
  name: greptimedb-operator
  namespace: greptimedb-admin
spec:
  replicas: 1
  selector:
    matchLabels:
      control-plane: controller-manager
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      annotations:
        kubectl.kubernetes.io/default-container: manager
      creationTimestamp: null
      labels:
        control-plane: controller-manager
    spec:
      containers:
      - args:
        - --enable-leader-election
        - --enable-admission-webhook
        command:
        - greptimedb-operator
        image: localhost:5001/greptime/greptimedb-operator:latest
        imagePullPolicy: IfNotPresent
        volumeMounts:
          - name: webhook-tls
            mountPath: /etc/webhook-tls
            readOnly: true 
        livenessProbe:
          failureThreshold: 3
          httpGet:
            path: /healthz
            port: 9494
            scheme: HTTP
          initialDelaySeconds: 15
          periodSeconds: 20
          successThreshold: 1
          timeoutSeconds: 1
        name: manager
        readinessProbe:
          failureThreshold: 3
          httpGet:
            path: /readyz
            port: 9494
            scheme: HTTP
          initialDelaySeconds: 5
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 1
        resources:
          limits:
            cpu: 500m
            memory: 128Mi
          requests:
            cpu: 10m
            memory: 64Mi
      volumes:
      - name: webhook-tls
        secret:
          secretName: webhook-server-tls
```

Create validating webhook:
```
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingWebhookConfiguration
metadata:
  name: greptimedb-operator-admission
webhooks:
- admissionReviewVersions:
  - v1
  clientConfig:
    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURMVENDQWhXZ0F3SUJBZ0lSQUxMVWxhWERtOC8wWGdoOHpZdU5wOWd3RFFZSktvWklodmNOQVFFTEJRQXcKQURBZUZ3MHlOVEEwTURjeE1qQTROREphRncweU5UQTNNRFl4TWpBNE5ESmFNQUF3Z2dFaU1BMEdDU3FHU0liMwpEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUUMvQm04OXhQUVQ3SFY1ZW9Qb2dLamhJdTBzQS9tVm5qVmNBMVAzCmJZem03RVRPVTVUSTBqVW5qbk1saDlKaXpmMEpKVFY5dlZhWDNDUlZ2Z2ZWWmJZWDFEdC9XY2ZVMVB6YVZ0cWkKOTl5ODliTDNwR2p0SWJOWS9zOWJzblB2d3NKcHlXbjI5dUY1UU5acUZKbkFlMTZLeHhHcVJwbEgvUXZjNWhuVAp0ck9rSmdIblZKVlJ3cUNncDRlc2NMRGE2VEpJNE1yRGlxL1U2VnVXSmZnczlFbHFJeFpEZndJbjI2WHg4Z0xyCmMvRTB1MUhRTmxBTExZeEhQbHoxaUoyTmxvYVNZQ1pjQy83U24vdCs1bTd1c0FIUDR2eW1qRjJrSlhaZktZeTEKRFc3ZkIrTmlxRFZOYUl2SlFxWkRlNGMycFZUeFZvTzFYRm5GNnExMzd1Z0c2NmJ6QWdNQkFBR2pnYUV3Z1o0dwpEZ1lEVlIwUEFRSC9CQVFEQWdXZ01Bd0dBMVVkRXdFQi93UUNNQUF3ZmdZRFZSMFJBUUgvQkhRd2NvSXdaM0psCmNIUnBiV1ZrWWkxdmNHVnlZWFJ2Y2kxM1pXSm9iMjlyTG1keVpYQjBhVzFsWkdJdFlXUnRhVzR1YzNaamdqNW4KY21Wd2RHbHRaV1JpTFc5d1pYSmhkRzl5TFhkbFltaHZiMnN1WjNKbGNIUnBiV1ZrWWkxaFpHMXBiaTV6ZG1NdQpZMngxYzNSbGNpNXNiMk5oYkRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQUQ5NjU0VzIrNGNMdTkyZUU2VHJVCjkwVTN5ZW9aSkk2YWthU2RVNXhRcURlcEdUTFZEaURBMVNlNmVlWlB5YnZkQ3YzdWZUd2M3NFg3MmwxL0JtTHgKTitsVk9EQ0J6dzVkcVJiSlUzVE1maXFEMGF5Vnp4enhOaDNQUlMrMGRTQVZXelI2enhWeENPVWFURkRNWXRGVgo4cVIyR2dsYVFoWW4reGkxd3hyTm8yOTE2R1hJR2FxZWZlM3hWbWl3b2g2VXhaMWF4WVJSTFZoZU9seHE5RThzCnc3NUtLZkdGSE5DNTJBcUlkajF2RVBIM2xoejcrYVZBMWR4R0hES0NqQjNGaGtzYlhyNERReGdFeVcyanpIWkEKZWVPQWFNTkJtTytmclJkM2t1L1doRkMyQm5mRzhrWTd6ZUF6OGtrMXVRSnhCZ1ozYURwV0puSmRNaHhKY1VVRApGUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
    service:
      name: greptimedb-operator-webhook
      namespace: greptimedb-admin
      path: /validate-greptime-io-v1alpha1-greptimedbcluster
  failurePolicy: Fail
  name: vgreptimedbcluster.kb.io
  rules:
  - apiGroups:
    - greptime.io
    apiVersions:
    - v1alpha1
    operations:
    - CREATE
    - UPDATE
    resources:
    - greptimedbclusters
  sideEffects: None
- admissionReviewVersions:
  - v1
  clientConfig:
    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURMVENDQWhXZ0F3SUJBZ0lSQUxMVWxhWERtOC8wWGdoOHpZdU5wOWd3RFFZSktvWklodmNOQVFFTEJRQXcKQURBZUZ3MHlOVEEwTURjeE1qQTROREphRncweU5UQTNNRFl4TWpBNE5ESmFNQUF3Z2dFaU1BMEdDU3FHU0liMwpEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUUMvQm04OXhQUVQ3SFY1ZW9Qb2dLamhJdTBzQS9tVm5qVmNBMVAzCmJZem03RVRPVTVUSTBqVW5qbk1saDlKaXpmMEpKVFY5dlZhWDNDUlZ2Z2ZWWmJZWDFEdC9XY2ZVMVB6YVZ0cWkKOTl5ODliTDNwR2p0SWJOWS9zOWJzblB2d3NKcHlXbjI5dUY1UU5acUZKbkFlMTZLeHhHcVJwbEgvUXZjNWhuVAp0ck9rSmdIblZKVlJ3cUNncDRlc2NMRGE2VEpJNE1yRGlxL1U2VnVXSmZnczlFbHFJeFpEZndJbjI2WHg4Z0xyCmMvRTB1MUhRTmxBTExZeEhQbHoxaUoyTmxvYVNZQ1pjQy83U24vdCs1bTd1c0FIUDR2eW1qRjJrSlhaZktZeTEKRFc3ZkIrTmlxRFZOYUl2SlFxWkRlNGMycFZUeFZvTzFYRm5GNnExMzd1Z0c2NmJ6QWdNQkFBR2pnYUV3Z1o0dwpEZ1lEVlIwUEFRSC9CQVFEQWdXZ01Bd0dBMVVkRXdFQi93UUNNQUF3ZmdZRFZSMFJBUUgvQkhRd2NvSXdaM0psCmNIUnBiV1ZrWWkxdmNHVnlZWFJ2Y2kxM1pXSm9iMjlyTG1keVpYQjBhVzFsWkdJdFlXUnRhVzR1YzNaamdqNW4KY21Wd2RHbHRaV1JpTFc5d1pYSmhkRzl5TFhkbFltaHZiMnN1WjNKbGNIUnBiV1ZrWWkxaFpHMXBiaTV6ZG1NdQpZMngxYzNSbGNpNXNiMk5oYkRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQUQ5NjU0VzIrNGNMdTkyZUU2VHJVCjkwVTN5ZW9aSkk2YWthU2RVNXhRcURlcEdUTFZEaURBMVNlNmVlWlB5YnZkQ3YzdWZUd2M3NFg3MmwxL0JtTHgKTitsVk9EQ0J6dzVkcVJiSlUzVE1maXFEMGF5Vnp4enhOaDNQUlMrMGRTQVZXelI2enhWeENPVWFURkRNWXRGVgo4cVIyR2dsYVFoWW4reGkxd3hyTm8yOTE2R1hJR2FxZWZlM3hWbWl3b2g2VXhaMWF4WVJSTFZoZU9seHE5RThzCnc3NUtLZkdGSE5DNTJBcUlkajF2RVBIM2xoejcrYVZBMWR4R0hES0NqQjNGaGtzYlhyNERReGdFeVcyanpIWkEKZWVPQWFNTkJtTytmclJkM2t1L1doRkMyQm5mRzhrWTd6ZUF6OGtrMXVRSnhCZ1ozYURwV0puSmRNaHhKY1VVRApGUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
    service:
      name: greptimedb-operator-webhook
      namespace: greptimedb-admin
      path: /validate-greptime-io-v1alpha1-greptimedbstandalone
  failurePolicy: Fail
  name: vgreptimedbstandalone.kb.io
  rules:
  - apiGroups:
    - greptime.io
    apiVersions:
    - v1alpha1
    operations:
    - CREATE
    - UPDATE
    resources:
    - greptimedbstandalones
  sideEffects: None
```

### Example
cat cluster.yaml:
```
apiVersion: greptime.io/v1alpha1
kind: GreptimeDBCluster
metadata:
  name: cluster-with-s3
spec:
  base:
    main:
      image: greptime/greptimedb:latest
  frontend:
    replicas: 1
  meta:
    replicas: 1
    etcdEndpoints:
      - "etcd.etcd-cluster.svc.cluster.local:2379"
  datanode:
    replicas: 1
  objectStorage:
    s3:
      bucket: "greptimedb"
      region: "ap-southeast-1"
      secretName: "s3-credentials"
      root: "cluster-with-s3-data"
    oss:
      bucket: "greptimedb"
      secretName: "oss-credentials"
      root: "cluster-with-oss-data"
      endpoint: "oss-cn-hangzhou.aliyuncs.com"
      region: "cn-hangzhou"
```

```
kubectl apply -f cluster.yaml
Error from server (Forbidden): error when creating "/Applications/go/greptimedb-operator/examples/cluster/s3/cluster.yaml": admission webhook "vgreptimedbcluster.kb.io" denied the request: only one storage provider can be set
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Enhanced resource validation for creation and update operations by implementing comprehensive error checks.
  - Streamlined deletion operations with updated guidance to bypass unnecessary validations.
  - Removed redundant checks in the processing flow for improved efficiency.

- **New Features**
  - Updated configuration defaults to use a new TLS certificate directory.
  - Enabled leader election by default to bolster operational reliability.
  - Introduced a control mechanism for admission webhook validation during the reconciliation process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->