### PR TITLE
feat: configure cache capacity and rename oss `secret-access-key` to `access-key-secret`

### DIFF
--- a/apis/v1alpha1/common.go
+++ b/apis/v1alpha1/common.go
@@ -626,6 +626,7 @@ type ObjectStorageProviderAccessor interface {
 	GetOSSStorage() *OSSStorage
 	GetAZBlobStorage() *AZBlobStorage
 	GetCacheFileStorage() *FileStorage
+	GetCacheStorage() *CacheStorage
 }
 
 var _ ObjectStorageProviderAccessor = &ObjectStorageProviderSpec{}
@@ -633,6 +634,13 @@ var _ ObjectStorageProviderAccessor = &ObjectStorageProviderSpec{}
 func (in *ObjectStorageProviderSpec) GetCacheFileStorage() *FileStorage {
 	if in != nil && in.Cache != nil {
 		return in.Cache.FileStorage
+	}
+	return nil
+}
+
+func (in *ObjectStorageProviderSpec) GetCacheStorage() *CacheStorage {
+	if in != nil {
+		return in.Cache
 	}
 	return nil
 }

--- a/apis/v1alpha1/common.go
+++ b/apis/v1alpha1/common.go
@@ -767,8 +767,8 @@ type OSSStorage struct {
 	// +required
 	Region string `json:"region"`
 
-	// The secret of storing the credentials of access key id and secret access key.
-	// The secret should contain keys named `access-key-id` and `secret-access-key`.
+	// The secret of storing the credentials of access key id and access key secret.
+	// The secret should contain keys named `access-key-id` and `access-key-secret`.
 	// The secret must be the same namespace with the GreptimeDBCluster resource.
 	// +optional
 	SecretName string `json:"secretName,omitempty"`

--- a/apis/v1alpha1/constants.go
+++ b/apis/v1alpha1/constants.go
@@ -91,6 +91,9 @@ const (
 	// SecretAccessKeySecretKey is the key for the secret access key in the secret.
 	SecretAccessKeySecretKey = "secret-access-key"
 
+	// AccessKeySecretSecretKey is the key for the access key secret in the secret.
+	AccessKeySecretSecretKey = "access-key-secret"
+
 	// ServiceAccountKey is the key for the service account in the secret.
 	ServiceAccountKey = "service-account-key"
 

--- a/apis/v1alpha1/validate.go
+++ b/apis/v1alpha1/validate.go
@@ -320,7 +320,7 @@ func checkGCSCredentialsSecret(ctx context.Context, client client.Client, namesp
 }
 
 func checkOSSCredentialsSecret(ctx context.Context, client client.Client, namespace, name string) error {
-	return checkSecretData(ctx, client, namespace, name, []string{AccessKeyIDSecretKey, SecretAccessKeySecretKey})
+	return checkSecretData(ctx, client, namespace, name, []string{AccessKeyIDSecretKey, AccessKeySecretSecretKey})
 }
 
 func checkS3CredentialsSecret(ctx context.Context, client client.Client, namespace, name string) error {

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -694,7 +694,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `bucket` _string_ | The data will be stored in the bucket. |  |  |
 | `region` _string_ | The region of the bucket. |  |  |
-| `secretName` _string_ | The secret of storing the credentials of access key id and secret access key.<br />The secret should contain keys named `access-key-id` and `secret-access-key`.<br />The secret must be the same namespace with the GreptimeDBCluster resource. |  |  |
+| `secretName` _string_ | The secret of storing the credentials of access key id and access key secret.<br />The secret should contain keys named `access-key-id` and `access-key-secret`.<br />The secret must be the same namespace with the GreptimeDBCluster resource. |  |  |
 | `root` _string_ | The OSS directory path. |  |  |
 | `endpoint` _string_ | The endpoint of the bucket. |  |  |
 

--- a/examples/cluster/oss/oss-credentials.yaml
+++ b/examples/cluster/oss/oss-credentials.yaml
@@ -5,4 +5,4 @@ metadata:
   name: oss-credentials
 stringData:
   access-key-id: "your-access-key-id"
-  secret-access-key: "your-secret-access-key"
+  access-key-secret: "your-access-key-secret"

--- a/examples/cluster/s3/cluster.yaml
+++ b/examples/cluster/s3/cluster.yaml
@@ -3,11 +3,9 @@ kind: GreptimeDBCluster
 metadata:
   name: cluster-with-s3
 spec:
-  initializer:
-    image: greptime-registry.cn-hangzhou.cr.aliyuncs.com/greptime/greptimedb-initializer:latest
   base:
     main:
-      image: greptime-registry.cn-hangzhou.cr.aliyuncs.com/greptime/greptimedb:latest
+      image: greptime/greptimedb:latest
   frontend:
     replicas: 1
   meta:
@@ -18,9 +16,7 @@ spec:
     replicas: 1
   objectStorage:
     s3:
-      bucket: "ap-southeast-1-test-bucket"
+      bucket: "greptimedb"
       region: "ap-southeast-1"
       secretName: "s3-credentials"
-      root: "cluster-with-s3-dataaaaa"
-    cache:
-      cacheCapacity: "5GiB"
+      root: "cluster-with-s3-data"

--- a/examples/cluster/s3/cluster.yaml
+++ b/examples/cluster/s3/cluster.yaml
@@ -3,9 +3,11 @@ kind: GreptimeDBCluster
 metadata:
   name: cluster-with-s3
 spec:
+  initializer:
+    image: greptime-registry.cn-hangzhou.cr.aliyuncs.com/greptime/greptimedb-initializer:latest
   base:
     main:
-      image: greptime/greptimedb:latest
+      image: greptime-registry.cn-hangzhou.cr.aliyuncs.com/greptime/greptimedb:latest
   frontend:
     replicas: 1
   meta:
@@ -16,7 +18,9 @@ spec:
     replicas: 1
   objectStorage:
     s3:
-      bucket: "greptimedb"
+      bucket: "ap-southeast-1-test-bucket"
       region: "ap-southeast-1"
       secretName: "s3-credentials"
-      root: "cluster-with-s3-data"
+      root: "cluster-with-s3-dataaaaa"
+    cache:
+      cacheCapacity: "5GiB"


### PR DESCRIPTION
- Add configure object storage `cache_capacity`.
- Rename OSS `secret-access-key` to `access-key-secret`.
The name is AccessKey secret: https://www.alibabacloud.com/help/en/ram/user-guide/create-an-accesskey-pair

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced storage configuration by introducing direct cache storage retrieval and an adjustable cache capacity.
	- Improved secret credential handling with updated key usage for consistent and secure access.

- **Refactor**
	- Refined storage configuration logic for clearer and more reliable setup.
	- Simplified method logic by removing unnecessary nil checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->