### PR TITLE
refactor: set default replicas when the field is unset

### DIFF
--- a/apis/v1alpha1/defaulting.go
+++ b/apis/v1alpha1/defaulting.go
@@ -175,10 +175,9 @@ func (in *GreptimeDBCluster) defaultSpec() *GreptimeDBClusterSpec {
 }
 
 func (in *GreptimeDBCluster) defaultFrontend() *FrontendSpec {
-	return &FrontendSpec{
+	defaultSpec := &FrontendSpec{
 		ComponentSpec: ComponentSpec{
 			Template: &PodTemplateSpec{},
-			Replicas: ptr.To(int32(DefaultReplicas)),
 			Logging:  &LoggingSpec{},
 		},
 		RPCPort:        DefaultRPCPort,
@@ -190,6 +189,12 @@ func (in *GreptimeDBCluster) defaultFrontend() *FrontendSpec {
 		},
 		RollingUpdate: defaultRollingUpdateForDeployment(),
 	}
+
+	if in.GetFrontend().GetReplicas() == nil {
+		defaultSpec.Replicas = ptr.To(int32(DefaultReplicas))
+	}
+
+	return defaultSpec
 }
 
 func (in *GreptimeDBCluster) defaultFrontends() []*FrontendSpec {
@@ -249,10 +254,9 @@ func (in *GreptimeDBCluster) defaultFrontends() []*FrontendSpec {
 }
 
 func (in *GreptimeDBCluster) defaultMeta() *MetaSpec {
-	return &MetaSpec{
+	defaultSpec := &MetaSpec{
 		ComponentSpec: ComponentSpec{
 			Template: &PodTemplateSpec{},
-			Replicas: ptr.To(int32(DefaultReplicas)),
 			Logging:  &LoggingSpec{},
 		},
 		RPCPort:              DefaultMetaRPCPort,
@@ -260,13 +264,18 @@ func (in *GreptimeDBCluster) defaultMeta() *MetaSpec {
 		EnableRegionFailover: ptr.To(false),
 		RollingUpdate:        defaultRollingUpdateForDeployment(),
 	}
+
+	if in.GetMeta().GetReplicas() == nil {
+		defaultSpec.Replicas = ptr.To(int32(DefaultReplicas))
+	}
+
+	return defaultSpec
 }
 
 func (in *GreptimeDBCluster) defaultDatanode() *DatanodeSpec {
-	return &DatanodeSpec{
+	defaultSpec := &DatanodeSpec{
 		ComponentSpec: ComponentSpec{
 			Template: &PodTemplateSpec{},
-			Replicas: ptr.To(int32(DefaultReplicas)),
 			Logging:  &LoggingSpec{},
 		},
 		RPCPort:       DefaultRPCPort,
@@ -274,18 +283,29 @@ func (in *GreptimeDBCluster) defaultDatanode() *DatanodeSpec {
 		Storage:       defaultDatanodeStorage(),
 		RollingUpdate: defaultRollingUpdateForStatefulSet(),
 	}
+
+	if in.GetDatanode().GetReplicas() == nil {
+		defaultSpec.Replicas = ptr.To(int32(DefaultReplicas))
+	}
+
+	return defaultSpec
 }
 
 func (in *GreptimeDBCluster) defaultFlownodeSpec() *FlownodeSpec {
-	return &FlownodeSpec{
+	defaultSpec := &FlownodeSpec{
 		ComponentSpec: ComponentSpec{
 			Template: &PodTemplateSpec{},
-			Replicas: ptr.To(int32(DefaultReplicas)),
 			Logging:  &LoggingSpec{},
 		},
 		RPCPort:  DefaultRPCPort,
 		HTTPPort: DefaultHTTPPort,
 	}
+
+	if in.GetFlownode().GetReplicas() == nil {
+		defaultSpec.Replicas = ptr.To(int32(DefaultReplicas))
+	}
+
+	return defaultSpec
 }
 
 func (in *GreptimeDBCluster) defaultMonitoringStandaloneSpec() *GreptimeDBStandaloneSpec {

--- a/apis/v1alpha1/greptimedbcluster_types.go
+++ b/apis/v1alpha1/greptimedbcluster_types.go
@@ -77,6 +77,13 @@ type MetaSpec struct {
 	RollingUpdate *appsv1.RollingUpdateDeployment `json:"rollingUpdate,omitempty"`
 }
 
+func (in *MetaSpec) GetReplicas() *int32 {
+	if in != nil && in.Replicas != nil {
+		return in.Replicas
+	}
+	return nil
+}
+
 func (in *MetaSpec) GetConfig() string {
 	if in != nil {
 		return in.Config
@@ -158,6 +165,13 @@ type FrontendSpec struct {
 	RollingUpdate *appsv1.RollingUpdateDeployment `json:"rollingUpdate,omitempty"`
 }
 
+func (in *FrontendSpec) GetReplicas() *int32 {
+	if in != nil && in.Replicas != nil {
+		return in.Replicas
+	}
+	return nil
+}
+
 func (in *FrontendSpec) GetTLS() *TLSSpec {
 	if in != nil {
 		return in.TLS
@@ -218,6 +232,13 @@ type DatanodeSpec struct {
 	RollingUpdate *appsv1.RollingUpdateStatefulSetStrategy `json:"rollingUpdate,omitempty"`
 }
 
+func (in *DatanodeSpec) GetReplicas() *int32 {
+	if in != nil && in.Replicas != nil {
+		return in.Replicas
+	}
+	return nil
+}
+
 func (in *DatanodeSpec) GetConfig() string {
 	if in != nil {
 		return in.Config
@@ -265,6 +286,13 @@ type FlownodeSpec struct {
 	// RollingUpdate is the rolling update configuration. We always use `RollingUpdate` strategy.
 	// +optional
 	RollingUpdate *appsv1.RollingUpdateStatefulSetStrategy `json:"rollingUpdate,omitempty"`
+}
+
+func (in *FlownodeSpec) GetReplicas() *int32 {
+	if in != nil && in.Replicas != nil {
+		return in.Replicas
+	}
+	return nil
 }
 
 func (in *FlownodeSpec) GetConfig() string {


### PR DESCRIPTION
After this PR is merged, we can set `0` replicas explicitly for the component. It's useful in the integration test.