### PR TITLE
refactor: add `RoleSpec` interface and clean the code

### DIFF
--- a/apis/v1alpha1/common.go
+++ b/apis/v1alpha1/common.go
@@ -72,6 +72,16 @@ const (
 	StandaloneKind ComponentKind = "standalone"
 )
 
+// RoleSpec is the interface for the role spec.
+// +kubebuilder:object:generate=false
+type RoleSpec interface {
+	// GetName returns the spec name if it has. It will return empty string if the spec has no name.
+	GetName() string
+
+	// GetRoleKind returns the role kind.
+	GetRoleKind() ComponentKind
+}
+
 // SlimPodSpec is a slimmed down version of corev1.PodSpec.
 // Most of the fields in SlimPodSpec are copied from `corev1.PodSpec`.
 type SlimPodSpec struct {

--- a/apis/v1alpha1/common.go
+++ b/apis/v1alpha1/common.go
@@ -52,24 +52,24 @@ const (
 	PhaseTerminating Phase = "Terminating"
 )
 
-// ComponentKind is the kind of the component in the cluster.
-type ComponentKind string
+// RoleKind is the role of the component in the cluster.
+type RoleKind string
 
 const (
-	// FrontendComponentKind is the frontend component kind.
-	FrontendComponentKind ComponentKind = "frontend"
+	// FrontendRoleKind is the frontend role.
+	FrontendRoleKind RoleKind = "frontend"
 
-	// DatanodeComponentKind is the datanode component kind.
-	DatanodeComponentKind ComponentKind = "datanode"
+	// DatanodeRoleKind is the datanode role.
+	DatanodeRoleKind RoleKind = "datanode"
 
-	// MetaComponentKind is the meta component kind.
-	MetaComponentKind ComponentKind = "meta"
+	// MetaRoleKind is the meta role.
+	MetaRoleKind RoleKind = "meta"
 
-	// FlownodeComponentKind is the flownode component kind.
-	FlownodeComponentKind ComponentKind = "flownode"
+	// FlownodeRoleKind is the flownode role.
+	FlownodeRoleKind RoleKind = "flownode"
 
-	// StandaloneKind is the standalone component kind.
-	StandaloneKind ComponentKind = "standalone"
+	// StandaloneRoleKind is the standalone role.
+	StandaloneRoleKind RoleKind = "standalone"
 )
 
 // RoleSpec is the interface for the role spec.
@@ -79,7 +79,7 @@ type RoleSpec interface {
 	GetName() string
 
 	// GetRoleKind returns the role kind.
-	GetRoleKind() ComponentKind
+	GetRoleKind() RoleKind
 }
 
 // SlimPodSpec is a slimmed down version of corev1.PodSpec.

--- a/apis/v1alpha1/greptimedbcluster_types.go
+++ b/apis/v1alpha1/greptimedbcluster_types.go
@@ -77,6 +77,17 @@ type MetaSpec struct {
 	RollingUpdate *appsv1.RollingUpdateDeployment `json:"rollingUpdate,omitempty"`
 }
 
+var _ RoleSpec = &MetaSpec{}
+
+// GetRoleKind returns the role kind.
+func (in *MetaSpec) GetRoleKind() ComponentKind {
+	return MetaComponentKind
+}
+
+func (in *MetaSpec) GetName() string {
+	return ""
+}
+
 func (in *MetaSpec) GetReplicas() *int32 {
 	if in != nil && in.Replicas != nil {
 		return in.Replicas
@@ -165,6 +176,13 @@ type FrontendSpec struct {
 	RollingUpdate *appsv1.RollingUpdateDeployment `json:"rollingUpdate,omitempty"`
 }
 
+var _ RoleSpec = &FrontendSpec{}
+
+// GetRoleKind returns the role kind.
+func (in *FrontendSpec) GetRoleKind() ComponentKind {
+	return FrontendComponentKind
+}
+
 func (in *FrontendSpec) GetReplicas() *int32 {
 	if in != nil && in.Replicas != nil {
 		return in.Replicas
@@ -232,6 +250,17 @@ type DatanodeSpec struct {
 	RollingUpdate *appsv1.RollingUpdateStatefulSetStrategy `json:"rollingUpdate,omitempty"`
 }
 
+var _ RoleSpec = &DatanodeSpec{}
+
+// GetRoleKind returns the role kind.
+func (in *DatanodeSpec) GetRoleKind() ComponentKind {
+	return DatanodeComponentKind
+}
+
+func (in *DatanodeSpec) GetName() string {
+	return ""
+}
+
 func (in *DatanodeSpec) GetReplicas() *int32 {
 	if in != nil && in.Replicas != nil {
 		return in.Replicas
@@ -286,6 +315,17 @@ type FlownodeSpec struct {
 	// RollingUpdate is the rolling update configuration. We always use `RollingUpdate` strategy.
 	// +optional
 	RollingUpdate *appsv1.RollingUpdateStatefulSetStrategy `json:"rollingUpdate,omitempty"`
+}
+
+var _ RoleSpec = &FlownodeSpec{}
+
+// GetRoleKind returns the role kind.
+func (in *FlownodeSpec) GetRoleKind() ComponentKind {
+	return FlownodeComponentKind
+}
+
+func (in *FlownodeSpec) GetName() string {
+	return ""
 }
 
 func (in *FlownodeSpec) GetReplicas() *int32 {

--- a/apis/v1alpha1/greptimedbcluster_types.go
+++ b/apis/v1alpha1/greptimedbcluster_types.go
@@ -80,8 +80,8 @@ type MetaSpec struct {
 var _ RoleSpec = &MetaSpec{}
 
 // GetRoleKind returns the role kind.
-func (in *MetaSpec) GetRoleKind() ComponentKind {
-	return MetaComponentKind
+func (in *MetaSpec) GetRoleKind() RoleKind {
+	return MetaRoleKind
 }
 
 func (in *MetaSpec) GetName() string {
@@ -179,8 +179,8 @@ type FrontendSpec struct {
 var _ RoleSpec = &FrontendSpec{}
 
 // GetRoleKind returns the role kind.
-func (in *FrontendSpec) GetRoleKind() ComponentKind {
-	return FrontendComponentKind
+func (in *FrontendSpec) GetRoleKind() RoleKind {
+	return FrontendRoleKind
 }
 
 func (in *FrontendSpec) GetReplicas() *int32 {
@@ -253,8 +253,8 @@ type DatanodeSpec struct {
 var _ RoleSpec = &DatanodeSpec{}
 
 // GetRoleKind returns the role kind.
-func (in *DatanodeSpec) GetRoleKind() ComponentKind {
-	return DatanodeComponentKind
+func (in *DatanodeSpec) GetRoleKind() RoleKind {
+	return DatanodeRoleKind
 }
 
 func (in *DatanodeSpec) GetName() string {
@@ -320,8 +320,8 @@ type FlownodeSpec struct {
 var _ RoleSpec = &FlownodeSpec{}
 
 // GetRoleKind returns the role kind.
-func (in *FlownodeSpec) GetRoleKind() ComponentKind {
-	return FlownodeComponentKind
+func (in *FlownodeSpec) GetRoleKind() RoleKind {
+	return FlownodeRoleKind
 }
 
 func (in *FlownodeSpec) GetName() string {

--- a/cmd/initializer/internal/config_generator.go
+++ b/cmd/initializer/internal/config_generator.go
@@ -32,7 +32,7 @@ type Options struct {
 	ConfigPath     string
 	InitConfigPath string
 	Namespace      string
-	ComponentKind  string
+	RoleKind       string
 
 	// For generating config of datanode or flownode.
 	RPCPort     int32
@@ -64,19 +64,19 @@ func (c *ConfigGenerator) Generate() error {
 	}
 
 	var configData []byte
-	switch c.ComponentKind {
-	case string(v1alpha1.DatanodeComponentKind):
+	switch c.RoleKind {
+	case string(v1alpha1.DatanodeRoleKind):
 		configData, err = c.generateDatanodeConfig(initConfig)
 		if err != nil {
 			return err
 		}
-	case string(v1alpha1.FlownodeComponentKind):
+	case string(v1alpha1.FlownodeRoleKind):
 		configData, err = c.generateFlownodeConfig(initConfig)
 		if err != nil {
 			return err
 		}
 	default:
-		return fmt.Errorf("unknown component kind: %s", c.ComponentKind)
+		return fmt.Errorf("unknown role kind: %s", c.RoleKind)
 	}
 
 	if err := os.WriteFile(c.ConfigPath, configData, 0644); err != nil {
@@ -90,7 +90,7 @@ func (c *ConfigGenerator) Generate() error {
 }
 
 func (c *ConfigGenerator) generateDatanodeConfig(initConfig []byte) ([]byte, error) {
-	cfg, err := dbconfig.NewFromComponentKind(v1alpha1.DatanodeComponentKind)
+	cfg, err := dbconfig.NewFromRoleKind(v1alpha1.DatanodeRoleKind)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func (c *ConfigGenerator) generateDatanodeConfig(initConfig []byte) ([]byte, err
 }
 
 func (c *ConfigGenerator) generateFlownodeConfig(initConfig []byte) ([]byte, error) {
-	cfg, err := dbconfig.NewFromComponentKind(v1alpha1.FlownodeComponentKind)
+	cfg, err := dbconfig.NewFromRoleKind(v1alpha1.FlownodeRoleKind)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/initializer/internal/config_generator_test.go
+++ b/cmd/initializer/internal/config_generator_test.go
@@ -49,7 +49,7 @@ func TestDatanodeConfigGenerator(t *testing.T) {
 		ConfigPath:          file.Name(),
 		InitConfigPath:      "testdata/datanode-config.toml",
 		Namespace:           testClusterNamespace,
-		ComponentKind:       string(v1alpha1.DatanodeComponentKind),
+		RoleKind:            string(v1alpha1.DatanodeRoleKind),
 		DatanodeRPCPort:     testRPCPort,
 		DatanodeServiceName: testClusterService,
 	}
@@ -110,7 +110,7 @@ func TestFlownodeConfigGenerator(t *testing.T) {
 		ConfigPath:     file.Name(),
 		InitConfigPath: "testdata/flownode-config.toml",
 		Namespace:      testClusterNamespace,
-		ComponentKind:  string(v1alpha1.FlownodeComponentKind),
+		RoleKind:       string(v1alpha1.FlownodeRoleKind),
 		RPCPort:        testRPCPort,
 		ServiceName:    testClusterService,
 	}

--- a/cmd/initializer/main.go
+++ b/cmd/initializer/main.go
@@ -30,7 +30,7 @@ func main() {
 	pflag.StringVar(&opts.ConfigPath, "config-path", "/etc/greptimedb/config.toml", "the config path")
 	pflag.StringVar(&opts.InitConfigPath, "init-config-path", "/etc/greptimedb/init-config.toml", "the init config path")
 	pflag.StringVar(&opts.Namespace, "namespace", "", "the namespace of greptimedb cluster")
-	pflag.StringVar(&opts.ComponentKind, "component-kind", "", "the component kind")
+	pflag.StringVar(&opts.RoleKind, "component-kind", "", "the component kind")
 
 	pflag.StringVar(&opts.ServiceName, "service-name", "", "the name of service")
 	pflag.Int32Var(&opts.RPCPort, "rpc-port", 4001, "the RPC port")

--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -43,18 +43,14 @@ const (
 	FileStorageTypeCache    FileStorageType = "cache"
 )
 
-// ResourceName returns the resource name for the given name and component kind.
+// ResourceName returns the resource name for the given name and role kind.
+// The format will be `${name}-${roleKind}-${extraNames[0]}-${extraNames[1]}...`.
 // If extraNames are provided, they will be appended to the resource name. For example,
-// - If the name is `my-cluster` and the component kind is `datanode`, the resource name will be `my-cluster-datanode`.
-// - If the name is `my-cluster` and the component kind is `datanode` and the extra names `read`, the resource name will be `my-cluster-datanode-read`.
-func ResourceName(name string, componentKind v1alpha1.RoleKind, extraNames ...string) string {
-	for _, extraName := range extraNames {
-		if extraName != "" {
-			name = name + "-" + extraName
-		}
-	}
-
-	return strings.Join([]string{name, string(componentKind)}, "-")
+// - If the name is `my-cluster` and the role kind is `datanode`, the resource name will be `my-cluster-datanode`.
+// - If the name is `my-cluster` and the role kind is `datanode` and the extra names `read`, the resource name will be `my-cluster-datanode-read`.
+func ResourceName(name string, roleKind v1alpha1.RoleKind, extraNames ...string) string {
+	parts := append([]string{name, string(roleKind)}, extraNames...)
+	return strings.Join(parts, "-")
 }
 
 func MountConfigDir(template *corev1.PodTemplateSpec, configMapName string) {

--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -49,8 +49,16 @@ const (
 // - If the name is `my-cluster` and the role kind is `datanode`, the resource name will be `my-cluster-datanode`.
 // - If the name is `my-cluster` and the role kind is `datanode` and the extra names `read`, the resource name will be `my-cluster-datanode-read`.
 func ResourceName(name string, roleKind v1alpha1.RoleKind, extraNames ...string) string {
-	parts := append([]string{name, string(roleKind)}, extraNames...)
-	return strings.Join(parts, "-")
+	const separator = "-"
+
+	baseName := strings.Join([]string{name, string(roleKind)}, separator)
+	for _, extraName := range extraNames {
+		if extraName != "" {
+			baseName = strings.Join([]string{baseName, extraName}, separator)
+		}
+	}
+
+	return baseName
 }
 
 func MountConfigDir(template *corev1.PodTemplateSpec, configMapName string) {

--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -47,7 +47,7 @@ const (
 // If extraNames are provided, they will be appended to the resource name. For example,
 // - If the name is `my-cluster` and the component kind is `datanode`, the resource name will be `my-cluster-datanode`.
 // - If the name is `my-cluster` and the component kind is `datanode` and the extra names `read`, the resource name will be `my-cluster-datanode-read`.
-func ResourceName(name string, componentKind v1alpha1.ComponentKind, extraNames ...string) string {
+func ResourceName(name string, componentKind v1alpha1.RoleKind, extraNames ...string) string {
 	for _, extraName := range extraNames {
 		if extraName != "" {
 			name = name + "-" + extraName
@@ -132,7 +132,7 @@ func GeneratePodMonitor(namespace, resourceName string, promSpec *v1alpha1.Prome
 	return pm, nil
 }
 
-func GeneratePodTemplateSpec(kind v1alpha1.ComponentKind, template *v1alpha1.PodTemplateSpec) *corev1.PodTemplateSpec {
+func GeneratePodTemplateSpec(kind v1alpha1.RoleKind, template *v1alpha1.PodTemplateSpec) *corev1.PodTemplateSpec {
 	if template == nil || template.MainContainer == nil {
 		return nil
 	}
@@ -187,7 +187,7 @@ func GeneratePodTemplateSpec(kind v1alpha1.ComponentKind, template *v1alpha1.Pod
 	return spec
 }
 
-func FileStorageToPVC(name string, fs v1alpha1.FileStorageAccessor, fsType FileStorageType, kind v1alpha1.ComponentKind) *corev1.PersistentVolumeClaim {
+func FileStorageToPVC(name string, fs v1alpha1.FileStorageAccessor, fsType FileStorageType, kind v1alpha1.RoleKind) *corev1.PersistentVolumeClaim {
 	var (
 		labels      map[string]string
 		annotations map[string]string
@@ -239,7 +239,7 @@ func FileStorageToPVC(name string, fs v1alpha1.FileStorageAccessor, fsType FileS
 	}
 }
 
-func GetPVCs(ctx context.Context, k8sClient client.Client, namespace, name string, kind v1alpha1.ComponentKind, fsType FileStorageType) ([]corev1.PersistentVolumeClaim, error) {
+func GetPVCs(ctx context.Context, k8sClient client.Client, namespace, name string, kind v1alpha1.RoleKind, fsType FileStorageType) ([]corev1.PersistentVolumeClaim, error) {
 	var labelSelector *metav1.LabelSelector
 	switch fsType {
 	case FileStorageTypeDatanode:

--- a/controllers/greptimedbcluster/controller_test.go
+++ b/controllers/greptimedbcluster/controller_test.go
@@ -61,27 +61,27 @@ var _ = Describe("Test greptimedbcluster controller", func() {
 
 		By("Check meta resource")
 		svc = &corev1.Service{}
-		checkResource(testNamespace, common.ResourceName(testClusterName, v1alpha1.MetaComponentKind), svc, req)
+		checkResource(testNamespace, common.ResourceName(testClusterName, v1alpha1.MetaRoleKind), svc, req)
 		deployment = &appsv1.Deployment{}
-		checkResource(testNamespace, common.ResourceName(testClusterName, v1alpha1.MetaComponentKind), deployment, req)
+		checkResource(testNamespace, common.ResourceName(testClusterName, v1alpha1.MetaRoleKind), deployment, req)
 
 		// Move forward to sync datanode.
 		Expect(makeDeploymentReady(deployment, cluster.Spec.Meta.Replicas)).NotTo(HaveOccurred(), "failed to update meta deployment status")
 
 		By("Check datanode resource")
 		svc = &corev1.Service{}
-		checkResource(testNamespace, common.ResourceName(testClusterName, v1alpha1.DatanodeComponentKind), svc, req)
+		checkResource(testNamespace, common.ResourceName(testClusterName, v1alpha1.DatanodeRoleKind), svc, req)
 		statefulSet = &appsv1.StatefulSet{}
-		checkResource(testNamespace, common.ResourceName(testClusterName, v1alpha1.DatanodeComponentKind), statefulSet, req)
+		checkResource(testNamespace, common.ResourceName(testClusterName, v1alpha1.DatanodeRoleKind), statefulSet, req)
 
 		// Move forward to sync frontend.
 		Expect(makeStatefulSetReady(statefulSet, cluster.Spec.Datanode.Replicas)).NotTo(HaveOccurred(), "failed to update datanode statefulset status")
 
 		By("Check frontend resource")
 		svc = &corev1.Service{}
-		checkResource(testNamespace, common.ResourceName(testClusterName, v1alpha1.FrontendComponentKind), svc, req)
+		checkResource(testNamespace, common.ResourceName(testClusterName, v1alpha1.FrontendRoleKind), svc, req)
 		deployment = &appsv1.Deployment{}
-		checkResource(testNamespace, common.ResourceName(testClusterName, v1alpha1.FrontendComponentKind), deployment, req)
+		checkResource(testNamespace, common.ResourceName(testClusterName, v1alpha1.FrontendRoleKind), deployment, req)
 
 		// Move forward to complete status.
 		Expect(makeDeploymentReady(deployment, cluster.Spec.Frontend.Replicas)).NotTo(HaveOccurred(), "failed to update frontend deployment status")

--- a/controllers/greptimedbcluster/deployers/common.go
+++ b/controllers/greptimedbcluster/deployers/common.go
@@ -68,7 +68,6 @@ func (c *CommonDeployer) GetCluster(crdObject client.Object) (*v1alpha1.Greptime
 type CommonBuilder struct {
 	Cluster       *v1alpha1.GreptimeDBCluster
 	ComponentKind v1alpha1.ComponentKind
-	Frontend      *v1alpha1.FrontendSpec
 
 	*deployer.DefaultBuilder
 }
@@ -80,7 +79,6 @@ func (c *CommonDeployer) NewCommonBuilder(crdObject client.Object, componentKind
 			Owner:  crdObject,
 		},
 		ComponentKind: componentKind,
-		Frontend:      new(v1alpha1.FrontendSpec),
 	}
 
 	cluster, err := c.GetCluster(crdObject)
@@ -92,38 +90,33 @@ func (c *CommonDeployer) NewCommonBuilder(crdObject client.Object, componentKind
 	return cb
 }
 
-func (c *CommonBuilder) GenerateConfigMap() (*corev1.ConfigMap, error) {
+func (c *CommonBuilder) GenerateConfigMap(roleSpec v1alpha1.RoleSpec) (*corev1.ConfigMap, error) {
 	var (
 		configData []byte
 		err        error
 	)
 
-	if c.ComponentKind == v1alpha1.FrontendComponentKind {
-		configData, err = dbconfig.FromFrontend(c.Frontend, c.ComponentKind)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		configData, err = dbconfig.FromCluster(c.Cluster, c.ComponentKind)
-		if err != nil {
-			return nil, err
-		}
+	configData, err = dbconfig.FromCluster(c.Cluster, roleSpec)
+	if err != nil {
+		return nil, err
 	}
 
-	return common.GenerateConfigMap(c.Cluster.Namespace, c.Cluster.Name, c.ComponentKind, configData, c.Frontend.Name)
+	resourceName := common.ResourceName(c.Cluster.Name, c.ComponentKind, roleSpec.GetName())
+
+	return common.GenerateConfigMap(c.Cluster.Namespace, resourceName, configData)
 }
 
 func (c *CommonBuilder) GeneratePodTemplateSpec(template *v1alpha1.PodTemplateSpec) *corev1.PodTemplateSpec {
 	return common.GeneratePodTemplateSpec(c.ComponentKind, template)
 }
 
-func (c *CommonBuilder) GeneratePodMonitor() (*monitoringv1.PodMonitor, error) {
-	return common.GeneratePodMonitor(c.Cluster.Namespace, c.Cluster.Name, c.ComponentKind, c.Cluster.Spec.PrometheusMonitor, c.Frontend.Name)
+func (c *CommonBuilder) GeneratePodMonitor(namespace, resourceName string) (*monitoringv1.PodMonitor, error) {
+	return common.GeneratePodMonitor(namespace, resourceName, c.Cluster.Spec.PrometheusMonitor)
 }
 
 // MountConfigDir mounts the configmap to the main container as '/etc/greptimedb/config.toml'.
-func (c *CommonBuilder) MountConfigDir(template *corev1.PodTemplateSpec) {
-	common.MountConfigDir(c.Cluster.Name, c.ComponentKind, template, c.Frontend.Name)
+func (c *CommonBuilder) MountConfigDir(template *corev1.PodTemplateSpec, configMapName string) {
+	common.MountConfigDir(template, configMapName)
 }
 
 // AddLogsVolume will create a shared volume for logs and mount it to the main container and sidecar container.

--- a/controllers/greptimedbcluster/deployers/datanode.go
+++ b/controllers/greptimedbcluster/deployers/datanode.go
@@ -346,11 +346,11 @@ func (b *datanodeBuilder) BuildConfigMap() deployer.Builder {
 		return b
 	}
 
-	if b.Cluster.Spec.Datanode == nil {
+	if b.Cluster.GetDatanode() == nil {
 		return b
 	}
 
-	cm, err := b.GenerateConfigMap()
+	cm, err := b.GenerateConfigMap(b.Cluster.GetDatanode())
 	if err != nil {
 		b.Err = err
 		return b
@@ -400,7 +400,7 @@ func (b *datanodeBuilder) BuildStatefulSet() deployer.Builder {
 		},
 	}
 
-	configData, err := dbconfig.FromCluster(b.Cluster, b.ComponentKind)
+	configData, err := dbconfig.FromCluster(b.Cluster, b.Cluster.GetDatanode())
 	if err != nil {
 		b.Err = err
 		return b
@@ -427,7 +427,7 @@ func (b *datanodeBuilder) BuildPodMonitor() deployer.Builder {
 		return b
 	}
 
-	pm, err := b.GeneratePodMonitor()
+	pm, err := b.GeneratePodMonitor(b.Cluster.Namespace, common.ResourceName(b.Cluster.Name, b.ComponentKind))
 	if err != nil {
 		b.Err = err
 		return b

--- a/controllers/greptimedbcluster/deployers/flownode.go
+++ b/controllers/greptimedbcluster/deployers/flownode.go
@@ -153,11 +153,11 @@ func (b *flownodeBuilder) BuildConfigMap() deployer.Builder {
 		return b
 	}
 
-	if b.Cluster.Spec.Flownode == nil {
+	if b.Cluster.GetFlownode() == nil {
 		return b
 	}
 
-	cm, err := b.GenerateConfigMap()
+	cm, err := b.GenerateConfigMap(b.Cluster.GetFlownode())
 	if err != nil {
 		b.Err = err
 		return b
@@ -206,7 +206,7 @@ func (b *flownodeBuilder) BuildStatefulSet() deployer.Builder {
 		},
 	}
 
-	configData, err := dbconfig.FromCluster(b.Cluster, b.ComponentKind)
+	configData, err := dbconfig.FromCluster(b.Cluster, b.Cluster.GetFlownode())
 	if err != nil {
 		b.Err = err
 		return b
@@ -233,7 +233,7 @@ func (b *flownodeBuilder) BuildPodMonitor() deployer.Builder {
 		return b
 	}
 
-	pm, err := b.GeneratePodMonitor()
+	pm, err := b.GeneratePodMonitor(b.Cluster.Namespace, common.ResourceName(b.Cluster.Name, b.ComponentKind))
 	if err != nil {
 		b.Err = err
 		return b

--- a/controllers/greptimedbcluster/deployers/meta.go
+++ b/controllers/greptimedbcluster/deployers/meta.go
@@ -77,7 +77,7 @@ func WithEtcdMaintenanceBuilder(builder EtcdMaintenanceBuilder) func(*MetaDeploy
 
 func (d *MetaDeployer) NewBuilder(crdObject client.Object) deployer.Builder {
 	return &metaBuilder{
-		CommonBuilder: d.NewCommonBuilder(crdObject, v1alpha1.MetaComponentKind),
+		CommonBuilder: d.NewCommonBuilder(crdObject, v1alpha1.MetaRoleKind),
 	}
 }
 
@@ -114,7 +114,7 @@ func (d *MetaDeployer) CheckAndUpdateStatus(ctx context.Context, highLevelObject
 
 		objectKey = client.ObjectKey{
 			Namespace: cluster.Namespace,
-			Name:      common.ResourceName(cluster.Name, v1alpha1.MetaComponentKind),
+			Name:      common.ResourceName(cluster.Name, v1alpha1.MetaRoleKind),
 		}
 	)
 
@@ -205,15 +205,15 @@ func (b *metaBuilder) BuildService() deployer.Builder {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: b.Cluster.Namespace,
-			Name:      common.ResourceName(b.Cluster.Name, b.ComponentKind),
+			Name:      common.ResourceName(b.Cluster.Name, b.RoleKind),
 			Labels: map[string]string{
-				constant.GreptimeDBComponentName: common.ResourceName(b.Cluster.Name, b.ComponentKind),
+				constant.GreptimeDBComponentName: common.ResourceName(b.Cluster.Name, b.RoleKind),
 			},
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeClusterIP,
 			Selector: map[string]string{
-				constant.GreptimeDBComponentName: common.ResourceName(b.Cluster.Name, b.ComponentKind),
+				constant.GreptimeDBComponentName: common.ResourceName(b.Cluster.Name, b.RoleKind),
 			},
 			Ports: b.servicePorts(),
 		},
@@ -239,17 +239,17 @@ func (b *metaBuilder) BuildDeployment() deployer.Builder {
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      common.ResourceName(b.Cluster.Name, b.ComponentKind),
+			Name:      common.ResourceName(b.Cluster.Name, b.RoleKind),
 			Namespace: b.Cluster.Namespace,
 			Labels: map[string]string{
-				constant.GreptimeDBComponentName: common.ResourceName(b.Cluster.Name, b.ComponentKind),
+				constant.GreptimeDBComponentName: common.ResourceName(b.Cluster.Name, b.RoleKind),
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: b.Cluster.Spec.Meta.Replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					constant.GreptimeDBComponentName: common.ResourceName(b.Cluster.Name, b.ComponentKind),
+					constant.GreptimeDBComponentName: common.ResourceName(b.Cluster.Name, b.RoleKind),
 				},
 			},
 			Template: *b.generatePodTemplateSpec(),
@@ -307,7 +307,7 @@ func (b *metaBuilder) BuildPodMonitor() deployer.Builder {
 		return b
 	}
 
-	pm, err := b.GeneratePodMonitor(b.Cluster.Namespace, common.ResourceName(b.Cluster.Name, b.ComponentKind))
+	pm, err := b.GeneratePodMonitor(b.Cluster.Namespace, common.ResourceName(b.Cluster.Name, b.RoleKind))
 	if err != nil {
 		b.Err = err
 		return b
@@ -331,9 +331,9 @@ func (b *metaBuilder) generatePodTemplateSpec() *corev1.PodTemplateSpec {
 	}
 
 	podTemplateSpec.Spec.Containers[constant.MainContainerIndex].Ports = b.containerPorts()
-	podTemplateSpec.Spec.Containers[constant.MainContainerIndex].Env = append(podTemplateSpec.Spec.Containers[constant.MainContainerIndex].Env, b.env(v1alpha1.MetaComponentKind)...)
+	podTemplateSpec.Spec.Containers[constant.MainContainerIndex].Env = append(podTemplateSpec.Spec.Containers[constant.MainContainerIndex].Env, b.env(v1alpha1.MetaRoleKind)...)
 
-	b.MountConfigDir(podTemplateSpec, common.ResourceName(b.Cluster.Name, b.ComponentKind))
+	b.MountConfigDir(podTemplateSpec, common.ResourceName(b.Cluster.Name, b.RoleKind))
 
 	if logging := b.Cluster.GetMeta().GetLogging(); logging != nil && !logging.IsOnlyLogToStdout() {
 		b.AddLogsVolume(podTemplateSpec, logging.GetLogsDir())
@@ -341,11 +341,11 @@ func (b *metaBuilder) generatePodTemplateSpec() *corev1.PodTemplateSpec {
 
 	if b.Cluster.GetMonitoring().IsEnabled() && b.Cluster.GetMonitoring().GetVector() != nil {
 		b.AddVectorConfigVolume(podTemplateSpec)
-		b.AddVectorSidecar(podTemplateSpec, v1alpha1.MetaComponentKind)
+		b.AddVectorSidecar(podTemplateSpec, v1alpha1.MetaRoleKind)
 	}
 
 	podTemplateSpec.ObjectMeta.Labels = util.MergeStringMap(podTemplateSpec.ObjectMeta.Labels, map[string]string{
-		constant.GreptimeDBComponentName: common.ResourceName(b.Cluster.Name, b.ComponentKind),
+		constant.GreptimeDBComponentName: common.ResourceName(b.Cluster.Name, b.RoleKind),
 	})
 
 	return podTemplateSpec

--- a/controllers/greptimedbcluster/deployers/meta.go
+++ b/controllers/greptimedbcluster/deployers/meta.go
@@ -260,7 +260,7 @@ func (b *metaBuilder) BuildDeployment() deployer.Builder {
 		},
 	}
 
-	configData, err := dbconfig.FromCluster(b.Cluster, b.ComponentKind)
+	configData, err := dbconfig.FromCluster(b.Cluster, b.Cluster.GetMeta())
 	if err != nil {
 		b.Err = err
 		return b
@@ -279,11 +279,11 @@ func (b *metaBuilder) BuildConfigMap() deployer.Builder {
 		return b
 	}
 
-	if b.Cluster.Spec.Meta == nil {
+	if b.Cluster.GetMeta() == nil {
 		return b
 	}
 
-	cm, err := b.GenerateConfigMap()
+	cm, err := b.GenerateConfigMap(b.Cluster.GetMeta())
 	if err != nil {
 		b.Err = err
 		return b
@@ -307,7 +307,7 @@ func (b *metaBuilder) BuildPodMonitor() deployer.Builder {
 		return b
 	}
 
-	pm, err := b.GeneratePodMonitor()
+	pm, err := b.GeneratePodMonitor(b.Cluster.Namespace, common.ResourceName(b.Cluster.Name, b.ComponentKind))
 	if err != nil {
 		b.Err = err
 		return b
@@ -333,7 +333,7 @@ func (b *metaBuilder) generatePodTemplateSpec() *corev1.PodTemplateSpec {
 	podTemplateSpec.Spec.Containers[constant.MainContainerIndex].Ports = b.containerPorts()
 	podTemplateSpec.Spec.Containers[constant.MainContainerIndex].Env = append(podTemplateSpec.Spec.Containers[constant.MainContainerIndex].Env, b.env(v1alpha1.MetaComponentKind)...)
 
-	b.MountConfigDir(podTemplateSpec)
+	b.MountConfigDir(podTemplateSpec, common.ResourceName(b.Cluster.Name, b.ComponentKind))
 
 	if logging := b.Cluster.GetMeta().GetLogging(); logging != nil && !logging.IsOnlyLogToStdout() {
 		b.AddLogsVolume(podTemplateSpec, logging.GetLogsDir())

--- a/controllers/greptimedbcluster/deployers/monitoring.go
+++ b/controllers/greptimedbcluster/deployers/monitoring.go
@@ -58,7 +58,7 @@ func NewMonitoringDeployer(mgr ctrl.Manager) *MonitoringDeployer {
 }
 
 func (d *MonitoringDeployer) NewBuilder(crdObject client.Object) deployer.Builder {
-	return &monitoringBuilder{CommonBuilder: d.NewCommonBuilder(crdObject, v1alpha1.StandaloneKind)}
+	return &monitoringBuilder{CommonBuilder: d.NewCommonBuilder(crdObject, v1alpha1.StandaloneRoleKind)}
 }
 
 func (d *MonitoringDeployer) Generate(crdObject client.Object) ([]client.Object, error) {
@@ -121,7 +121,7 @@ func (d *MonitoringDeployer) CheckAndUpdateStatus(ctx context.Context, crdObject
 				}
 			}
 
-			cluster.Status.Monitoring.InternalDNSName = fmt.Sprintf("%s.%s.svc.cluster.local", common.ResourceName(common.MonitoringServiceName(cluster.Name), v1alpha1.StandaloneKind), cluster.Namespace)
+			cluster.Status.Monitoring.InternalDNSName = fmt.Sprintf("%s.%s.svc.cluster.local", common.ResourceName(common.MonitoringServiceName(cluster.Name), v1alpha1.StandaloneRoleKind), cluster.Namespace)
 			if err := UpdateStatus(ctx, cluster, d.Client); err != nil {
 				klog.Errorf("Failed to update status: %s", err)
 			}
@@ -153,7 +153,7 @@ func (d *MonitoringDeployer) createPipeline(cluster *v1alpha1.GreptimeDBCluster,
 	}
 	w.Close()
 
-	standaloneName := common.ResourceName(common.MonitoringServiceName(cluster.Name), v1alpha1.StandaloneKind)
+	standaloneName := common.ResourceName(common.MonitoringServiceName(cluster.Name), v1alpha1.StandaloneRoleKind)
 
 	// FIXME(zyy17): Make the port configurable.
 	svc := fmt.Sprintf("%s.%s.svc.cluster.local:%d", standaloneName, cluster.Namespace, v1alpha1.DefaultHTTPPort)
@@ -244,7 +244,7 @@ func (d *MonitoringDeployer) defaultSlowQueriesPipeline() (string, error) {
 func (d *MonitoringDeployer) getPipeline(ctx context.Context, cluster *v1alpha1.GreptimeDBCluster, pipelineName string) (string, error) {
 	cfg := mysql.Config{
 		Net:                  "tcp",
-		Addr:                 fmt.Sprintf("%s.%s.svc.cluster.local:%d", common.ResourceName(common.MonitoringServiceName(cluster.Name), v1alpha1.StandaloneKind), cluster.Namespace, v1alpha1.DefaultMySQLPort),
+		Addr:                 fmt.Sprintf("%s.%s.svc.cluster.local:%d", common.ResourceName(common.MonitoringServiceName(cluster.Name), v1alpha1.StandaloneRoleKind), cluster.Namespace, v1alpha1.DefaultMySQLPort),
 		DBName:               "greptime_private",
 		AllowNativePasswords: true,
 		Timeout:              5 * time.Second,

--- a/controllers/greptimedbstandalone/deployer.go
+++ b/controllers/greptimedbstandalone/deployer.go
@@ -220,7 +220,7 @@ func (b *standaloneBuilder) BuildConfigMap() deployer.Builder {
 		return b
 	}
 
-	cm, err := common.GenerateConfigMap(b.standalone.Namespace, b.standalone.Name, v1alpha1.StandaloneKind, configData, "")
+	cm, err := common.GenerateConfigMap(b.standalone.Namespace, common.ResourceName(b.standalone.Name, v1alpha1.StandaloneKind), configData)
 	if err != nil {
 		b.Err = err
 		return b
@@ -294,7 +294,7 @@ func (b *standaloneBuilder) generatePodTemplateSpec() corev1.PodTemplateSpec {
 		constant.GreptimeDBComponentName: common.ResourceName(b.standalone.Name, v1alpha1.StandaloneKind),
 	})
 
-	common.MountConfigDir(b.standalone.Name, v1alpha1.StandaloneKind, template, "")
+	common.MountConfigDir(template, common.ResourceName(b.standalone.Name, v1alpha1.StandaloneKind))
 
 	if b.standalone.Spec.TLS != nil {
 		b.mountTLSSecret(template)

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -873,6 +873,8 @@ _Appears in:_
 | `fs` _[FileStorage](#filestorage)_ | FileStorage is the file storage configuration for the raft-engine WAL.<br />If the file storage is not specified, WAL will use DatanodeStorageSpec. |  |  |
 
 
+
+
 #### S3Storage
 
 

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -51,8 +51,6 @@ _Appears in:_
 | `cacheCapacity` _string_ | CacheCapacity is the capacity of the cache. |  |  |
 
 
-
-
 #### ComponentSpec
 
 
@@ -871,6 +869,8 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `fs` _[FileStorage](#filestorage)_ | FileStorage is the file storage configuration for the raft-engine WAL.<br />If the file storage is not specified, WAL will use DatanodeStorageSpec. |  |  |
+
+
 
 
 

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -327,7 +327,7 @@ func (s *Server) getPods(ctx context.Context, cluster greptimev1alpha1.GreptimeD
 	var frontendGroupsPod corev1.PodList
 	for _, frontend := range cluster.GetFrontendGroups() {
 		if err := s.List(ctx, &frontendGroupsPod, client.InNamespace(cluster.Namespace),
-			client.MatchingLabels{constant.GreptimeDBComponentName: common.AdditionalResourceName(cluster.Name, frontend.Name, kind)}); err != nil {
+			client.MatchingLabels{constant.GreptimeDBComponentName: common.ResourceName(cluster.Name, kind, frontend.Name)}); err != nil {
 			return err
 		}
 		internalPods.Items = append(internalPods.Items, frontendGroupsPod.Items...)

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -302,11 +302,11 @@ func (s *Server) getCluster(c *gin.Context) {
 func (s *Server) getTopology(ctx context.Context, cluster greptimev1alpha1.GreptimeDBCluster) (*GreptimeDBClusterTopology, error) {
 	topology := new(GreptimeDBClusterTopology)
 
-	for _, kind := range []greptimev1alpha1.ComponentKind{
-		greptimev1alpha1.MetaComponentKind,
-		greptimev1alpha1.DatanodeComponentKind,
-		greptimev1alpha1.FrontendComponentKind,
-		greptimev1alpha1.FlownodeComponentKind,
+	for _, kind := range []greptimev1alpha1.RoleKind{
+		greptimev1alpha1.MetaRoleKind,
+		greptimev1alpha1.DatanodeRoleKind,
+		greptimev1alpha1.FrontendRoleKind,
+		greptimev1alpha1.FlownodeRoleKind,
 	} {
 		if err := s.getPods(ctx, cluster, kind, topology); err != nil {
 			return nil, err
@@ -316,7 +316,7 @@ func (s *Server) getTopology(ctx context.Context, cluster greptimev1alpha1.Grept
 	return topology, nil
 }
 
-func (s *Server) getPods(ctx context.Context, cluster greptimev1alpha1.GreptimeDBCluster, kind greptimev1alpha1.ComponentKind, topology *GreptimeDBClusterTopology) error {
+func (s *Server) getPods(ctx context.Context, cluster greptimev1alpha1.GreptimeDBCluster, kind greptimev1alpha1.RoleKind, topology *GreptimeDBClusterTopology) error {
 	var internalPods corev1.PodList
 	if err := s.List(ctx, &internalPods, client.InNamespace(cluster.Namespace),
 		client.MatchingLabels{constant.GreptimeDBComponentName: common.ResourceName(cluster.Name, kind)}); err != nil {
@@ -356,13 +356,13 @@ func (s *Server) getPods(ctx context.Context, cluster greptimev1alpha1.GreptimeD
 	}
 
 	switch kind {
-	case greptimev1alpha1.MetaComponentKind:
+	case greptimev1alpha1.MetaRoleKind:
 		topology.Meta = pods
-	case greptimev1alpha1.DatanodeComponentKind:
+	case greptimev1alpha1.DatanodeRoleKind:
 		topology.Datanode = pods
-	case greptimev1alpha1.FrontendComponentKind:
+	case greptimev1alpha1.FrontendRoleKind:
 		topology.Frontend = pods
-	case greptimev1alpha1.FlownodeComponentKind:
+	case greptimev1alpha1.FlownodeRoleKind:
 		topology.Flownode = pods
 	}
 

--- a/pkg/dbconfig/datanode_config.go
+++ b/pkg/dbconfig/datanode_config.go
@@ -15,6 +15,8 @@
 package dbconfig
 
 import (
+	"fmt"
+
 	"k8s.io/utils/ptr"
 
 	"github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1"
@@ -42,7 +44,16 @@ type DatanodeConfig struct {
 }
 
 // ConfigureByCluster configures the datanode config by the given cluster.
-func (c *DatanodeConfig) ConfigureByCluster(cluster *v1alpha1.GreptimeDBCluster) error {
+func (c *DatanodeConfig) ConfigureByCluster(cluster *v1alpha1.GreptimeDBCluster, roleSpec v1alpha1.RoleSpec) error {
+	if roleSpec.GetRoleKind() != v1alpha1.DatanodeComponentKind {
+		return fmt.Errorf("invalid role kind: %s", roleSpec.GetRoleKind())
+	}
+
+	datanodeSpec, ok := roleSpec.(*v1alpha1.DatanodeSpec)
+	if !ok {
+		return fmt.Errorf("invalid role spec type: %T", roleSpec)
+	}
+
 	if objectStorage := cluster.GetObjectStorageProvider(); objectStorage != nil {
 		if err := c.ConfigureObjectStorage(cluster.GetNamespace(), objectStorage); err != nil {
 			return err
@@ -54,11 +65,11 @@ func (c *DatanodeConfig) ConfigureByCluster(cluster *v1alpha1.GreptimeDBCluster)
 		c.WalDir = ptr.To(cluster.GetWALDir())
 	}
 
-	if dataHome := cluster.GetDatanode().GetDataHome(); dataHome != "" {
+	if dataHome := datanodeSpec.GetDataHome(); dataHome != "" {
 		c.StorageDataHome = ptr.To(dataHome)
 	}
 
-	if cfg := cluster.GetDatanode().GetConfig(); cfg != "" {
+	if cfg := datanodeSpec.GetConfig(); cfg != "" {
 		if err := c.SetInputConfig(cfg); err != nil {
 			return err
 		}
@@ -69,17 +80,13 @@ func (c *DatanodeConfig) ConfigureByCluster(cluster *v1alpha1.GreptimeDBCluster)
 		c.WalBrokerEndpoints = kafka.GetBrokerEndpoints()
 	}
 
-	c.ConfigureLogging(cluster.GetDatanode().GetLogging())
+	c.ConfigureLogging(datanodeSpec.GetLogging())
 
 	return nil
 }
 
 // ConfigureByStandalone is not need to implement in cluster mode.
 func (c *DatanodeConfig) ConfigureByStandalone(_ *v1alpha1.GreptimeDBStandalone) error {
-	return nil
-}
-
-func (c *DatanodeConfig) ConfigureByFrontend(_ *v1alpha1.FrontendSpec) error {
 	return nil
 }
 

--- a/pkg/dbconfig/datanode_config.go
+++ b/pkg/dbconfig/datanode_config.go
@@ -45,7 +45,7 @@ type DatanodeConfig struct {
 
 // ConfigureByCluster configures the datanode config by the given cluster.
 func (c *DatanodeConfig) ConfigureByCluster(cluster *v1alpha1.GreptimeDBCluster, roleSpec v1alpha1.RoleSpec) error {
-	if roleSpec.GetRoleKind() != v1alpha1.DatanodeComponentKind {
+	if roleSpec.GetRoleKind() != v1alpha1.DatanodeRoleKind {
 		return fmt.Errorf("invalid role kind: %s", roleSpec.GetRoleKind())
 	}
 
@@ -91,8 +91,8 @@ func (c *DatanodeConfig) ConfigureByStandalone(_ *v1alpha1.GreptimeDBStandalone)
 }
 
 // Kind returns the component kind of the datanode.
-func (c *DatanodeConfig) Kind() v1alpha1.ComponentKind {
-	return v1alpha1.DatanodeComponentKind
+func (c *DatanodeConfig) Kind() v1alpha1.RoleKind {
+	return v1alpha1.DatanodeRoleKind
 }
 
 // GetInputConfig returns the input config.

--- a/pkg/dbconfig/dbconfig.go
+++ b/pkg/dbconfig/dbconfig.go
@@ -35,7 +35,7 @@ const (
 // Config is the interface for the config of greptimedb.
 type Config interface {
 	// Kind returns the component kind of the config.
-	Kind() v1alpha1.ComponentKind
+	Kind() v1alpha1.RoleKind
 
 	// ConfigureByCluster configures the config by the given cluster.
 	ConfigureByCluster(cluster *v1alpha1.GreptimeDBCluster, roleSpec v1alpha1.RoleSpec) error
@@ -50,18 +50,18 @@ type Config interface {
 	SetInputConfig(input string) error
 }
 
-// NewFromComponentKind creates config from the component kind.
-func NewFromComponentKind(kind v1alpha1.ComponentKind) (Config, error) {
+// NewFromRoleKind creates config from the role kind.
+func NewFromRoleKind(kind v1alpha1.RoleKind) (Config, error) {
 	switch kind {
-	case v1alpha1.MetaComponentKind:
+	case v1alpha1.MetaRoleKind:
 		return &MetaConfig{}, nil
-	case v1alpha1.DatanodeComponentKind:
+	case v1alpha1.DatanodeRoleKind:
 		return &DatanodeConfig{}, nil
-	case v1alpha1.FrontendComponentKind:
+	case v1alpha1.FrontendRoleKind:
 		return &FrontendConfig{}, nil
-	case v1alpha1.FlownodeComponentKind:
+	case v1alpha1.FlownodeRoleKind:
 		return &FlownodeConfig{}, nil
-	case v1alpha1.StandaloneKind:
+	case v1alpha1.StandaloneRoleKind:
 		return &StandaloneConfig{}, nil
 	default:
 		return nil, fmt.Errorf("unknown component kind: %s", kind)
@@ -85,7 +85,7 @@ func Marshal(config Config) ([]byte, error) {
 
 // FromCluster creates config data from the cluster CRD.
 func FromCluster(cluster *v1alpha1.GreptimeDBCluster, roleSpec v1alpha1.RoleSpec) ([]byte, error) {
-	cfg, err := NewFromComponentKind(roleSpec.GetRoleKind())
+	cfg, err := NewFromRoleKind(roleSpec.GetRoleKind())
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func FromCluster(cluster *v1alpha1.GreptimeDBCluster, roleSpec v1alpha1.RoleSpec
 
 // FromStandalone creates config data from the standalone CRD.
 func FromStandalone(standalone *v1alpha1.GreptimeDBStandalone) ([]byte, error) {
-	cfg, err := NewFromComponentKind(v1alpha1.StandaloneKind)
+	cfg, err := NewFromRoleKind(v1alpha1.StandaloneRoleKind)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dbconfig/dbconfig.go
+++ b/pkg/dbconfig/dbconfig.go
@@ -38,13 +38,10 @@ type Config interface {
 	Kind() v1alpha1.ComponentKind
 
 	// ConfigureByCluster configures the config by the given cluster.
-	ConfigureByCluster(cluster *v1alpha1.GreptimeDBCluster) error
+	ConfigureByCluster(cluster *v1alpha1.GreptimeDBCluster, roleSpec v1alpha1.RoleSpec) error
 
 	// ConfigureByStandalone configures the config by the given standalone.
 	ConfigureByStandalone(standalone *v1alpha1.GreptimeDBStandalone) error
-
-	// ConfigureByFrontend configures the config by the given frontend.
-	ConfigureByFrontend(cluster *v1alpha1.FrontendSpec) error
 
 	// GetInputConfig returns the input config.
 	GetInputConfig() string
@@ -87,26 +84,13 @@ func Marshal(config Config) ([]byte, error) {
 }
 
 // FromCluster creates config data from the cluster CRD.
-func FromCluster(cluster *v1alpha1.GreptimeDBCluster, componentKind v1alpha1.ComponentKind) ([]byte, error) {
-	cfg, err := NewFromComponentKind(componentKind)
+func FromCluster(cluster *v1alpha1.GreptimeDBCluster, roleSpec v1alpha1.RoleSpec) ([]byte, error) {
+	cfg, err := NewFromComponentKind(roleSpec.GetRoleKind())
 	if err != nil {
 		return nil, err
 	}
 
-	if err := cfg.ConfigureByCluster(cluster); err != nil {
-		return nil, err
-	}
-
-	return Marshal(cfg)
-}
-
-func FromFrontend(frontend *v1alpha1.FrontendSpec, componentKind v1alpha1.ComponentKind) ([]byte, error) {
-	cfg, err := NewFromComponentKind(componentKind)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := cfg.ConfigureByFrontend(frontend); err != nil {
+	if err := cfg.ConfigureByCluster(cluster, roleSpec); err != nil {
 		return nil, err
 	}
 

--- a/pkg/dbconfig/dbconfig_test.go
+++ b/pkg/dbconfig/dbconfig_test.go
@@ -62,7 +62,7 @@ func TestFromClusterForDatanodeConfig(t *testing.T) {
   provider = "kafka"
 `
 
-	data, err := FromCluster(testCluster, v1alpha1.DatanodeComponentKind)
+	data, err := FromCluster(testCluster, testCluster.GetDatanode())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +122,7 @@ key2 = 'value2'
   type = "S3"
 `
 
-	data, err := FromCluster(testCluster, v1alpha1.DatanodeComponentKind)
+	data, err := FromCluster(testCluster, testCluster.GetDatanode())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/dbconfig/flownode_config.go
+++ b/pkg/dbconfig/flownode_config.go
@@ -15,6 +15,8 @@
 package dbconfig
 
 import (
+	"fmt"
+
 	"github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1"
 )
 
@@ -34,8 +36,17 @@ type FlownodeConfig struct {
 }
 
 // ConfigureByCluster configures the datanode config by the given cluster.
-func (c *FlownodeConfig) ConfigureByCluster(cluster *v1alpha1.GreptimeDBCluster) error {
-	if cfg := cluster.GetFlownode().GetConfig(); cfg != "" {
+func (c *FlownodeConfig) ConfigureByCluster(cluster *v1alpha1.GreptimeDBCluster, roleSpec v1alpha1.RoleSpec) error {
+	if roleSpec.GetRoleKind() != v1alpha1.FlownodeComponentKind {
+		return fmt.Errorf("invalid role kind: %s", roleSpec.GetRoleKind())
+	}
+
+	flownodeSpec, ok := roleSpec.(*v1alpha1.FlownodeSpec)
+	if !ok {
+		return fmt.Errorf("invalid role spec type: %T", roleSpec)
+	}
+
+	if cfg := flownodeSpec.GetConfig(); cfg != "" {
 		if err := c.SetInputConfig(cfg); err != nil {
 			return err
 		}
@@ -48,10 +59,6 @@ func (c *FlownodeConfig) ConfigureByCluster(cluster *v1alpha1.GreptimeDBCluster)
 
 // ConfigureByStandalone is not need to implement in cluster mode.
 func (c *FlownodeConfig) ConfigureByStandalone(_ *v1alpha1.GreptimeDBStandalone) error {
-	return nil
-}
-
-func (c *FlownodeConfig) ConfigureByFrontend(_ *v1alpha1.FrontendSpec) error {
 	return nil
 }
 

--- a/pkg/dbconfig/flownode_config.go
+++ b/pkg/dbconfig/flownode_config.go
@@ -37,7 +37,7 @@ type FlownodeConfig struct {
 
 // ConfigureByCluster configures the datanode config by the given cluster.
 func (c *FlownodeConfig) ConfigureByCluster(cluster *v1alpha1.GreptimeDBCluster, roleSpec v1alpha1.RoleSpec) error {
-	if roleSpec.GetRoleKind() != v1alpha1.FlownodeComponentKind {
+	if roleSpec.GetRoleKind() != v1alpha1.FlownodeRoleKind {
 		return fmt.Errorf("invalid role kind: %s", roleSpec.GetRoleKind())
 	}
 
@@ -63,8 +63,8 @@ func (c *FlownodeConfig) ConfigureByStandalone(_ *v1alpha1.GreptimeDBStandalone)
 }
 
 // Kind returns the component kind of the datanode.
-func (c *FlownodeConfig) Kind() v1alpha1.ComponentKind {
-	return v1alpha1.FlownodeComponentKind
+func (c *FlownodeConfig) Kind() v1alpha1.RoleKind {
+	return v1alpha1.FlownodeRoleKind
 }
 
 // GetInputConfig returns the input config.

--- a/pkg/dbconfig/frontend_config.go
+++ b/pkg/dbconfig/frontend_config.go
@@ -15,6 +15,8 @@
 package dbconfig
 
 import (
+	"fmt"
+
 	"github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1"
 )
 
@@ -29,21 +31,25 @@ type FrontendConfig struct {
 	InputConfig string
 }
 
-// ConfigureByFrontend configures the frontend configuration by the given cluster.
-func (c *FrontendConfig) ConfigureByFrontend(frontend *v1alpha1.FrontendSpec) error {
-	if cfg := frontend.GetConfig(); cfg != "" {
+// ConfigureByCluster is not need to implement in frontend components.
+func (c *FrontendConfig) ConfigureByCluster(_ *v1alpha1.GreptimeDBCluster, roleSpec v1alpha1.RoleSpec) error {
+	if roleSpec.GetRoleKind() != v1alpha1.FrontendComponentKind {
+		return fmt.Errorf("invalid role kind: %s", roleSpec.GetRoleKind())
+	}
+
+	frontendSpec, ok := roleSpec.(*v1alpha1.FrontendSpec)
+	if !ok {
+		return fmt.Errorf("invalid role spec type: %T", roleSpec)
+	}
+
+	if cfg := frontendSpec.GetConfig(); cfg != "" {
 		if err := c.SetInputConfig(cfg); err != nil {
 			return err
 		}
 	}
 
-	c.ConfigureLogging(frontend.GetLogging())
+	c.ConfigureLogging(frontendSpec.GetLogging())
 
-	return nil
-}
-
-// ConfigureByCluster is not need to implement in frontend components.
-func (c *FrontendConfig) ConfigureByCluster(_ *v1alpha1.GreptimeDBCluster) error {
 	return nil
 }
 

--- a/pkg/dbconfig/frontend_config.go
+++ b/pkg/dbconfig/frontend_config.go
@@ -33,7 +33,7 @@ type FrontendConfig struct {
 
 // ConfigureByCluster is not need to implement in frontend components.
 func (c *FrontendConfig) ConfigureByCluster(_ *v1alpha1.GreptimeDBCluster, roleSpec v1alpha1.RoleSpec) error {
-	if roleSpec.GetRoleKind() != v1alpha1.FrontendComponentKind {
+	if roleSpec.GetRoleKind() != v1alpha1.FrontendRoleKind {
 		return fmt.Errorf("invalid role kind: %s", roleSpec.GetRoleKind())
 	}
 
@@ -59,8 +59,8 @@ func (c *FrontendConfig) ConfigureByStandalone(_ *v1alpha1.GreptimeDBStandalone)
 }
 
 // Kind returns the component kind of the frontend.
-func (c *FrontendConfig) Kind() v1alpha1.ComponentKind {
-	return v1alpha1.FrontendComponentKind
+func (c *FrontendConfig) Kind() v1alpha1.RoleKind {
+	return v1alpha1.FrontendRoleKind
 }
 
 // GetInputConfig returns the input config of the frontend.

--- a/pkg/dbconfig/meta_config.go
+++ b/pkg/dbconfig/meta_config.go
@@ -15,6 +15,8 @@
 package dbconfig
 
 import (
+	"fmt"
+
 	"k8s.io/utils/ptr"
 
 	"github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1"
@@ -44,14 +46,23 @@ type MetaConfig struct {
 }
 
 // ConfigureByCluster configures the meta config by the given cluster.
-func (c *MetaConfig) ConfigureByCluster(cluster *v1alpha1.GreptimeDBCluster) error {
-	c.EnableRegionFailover = ptr.To(cluster.GetMeta().IsEnableRegionFailover())
+func (c *MetaConfig) ConfigureByCluster(cluster *v1alpha1.GreptimeDBCluster, roleSpec v1alpha1.RoleSpec) error {
+	if roleSpec.GetRoleKind() != v1alpha1.MetaComponentKind {
+		return fmt.Errorf("invalid role kind: %s", roleSpec.GetRoleKind())
+	}
 
-	if prefix := cluster.GetMeta().GetStoreKeyPrefix(); prefix != "" {
+	metaSpec, ok := roleSpec.(*v1alpha1.MetaSpec)
+	if !ok {
+		return fmt.Errorf("invalid role spec type: %T", roleSpec)
+	}
+
+	c.EnableRegionFailover = ptr.To(metaSpec.IsEnableRegionFailover())
+
+	if prefix := metaSpec.GetStoreKeyPrefix(); prefix != "" {
 		c.StoreKeyPrefix = ptr.To(prefix)
 	}
 
-	if cfg := cluster.GetMeta().GetConfig(); cfg != "" {
+	if cfg := metaSpec.GetConfig(); cfg != "" {
 		if err := c.SetInputConfig(cfg); err != nil {
 			return err
 		}
@@ -62,17 +73,13 @@ func (c *MetaConfig) ConfigureByCluster(cluster *v1alpha1.GreptimeDBCluster) err
 		c.WalBrokerEndpoints = kafka.GetBrokerEndpoints()
 	}
 
-	c.ConfigureLogging(cluster.GetMeta().GetLogging())
+	c.ConfigureLogging(metaSpec.GetLogging())
 
 	return nil
 }
 
 // ConfigureByStandalone is not need to implement in cluster mode.
 func (c *MetaConfig) ConfigureByStandalone(_ *v1alpha1.GreptimeDBStandalone) error {
-	return nil
-}
-
-func (c *MetaConfig) ConfigureByFrontend(_ *v1alpha1.FrontendSpec) error {
 	return nil
 }
 

--- a/pkg/dbconfig/meta_config.go
+++ b/pkg/dbconfig/meta_config.go
@@ -47,7 +47,7 @@ type MetaConfig struct {
 
 // ConfigureByCluster configures the meta config by the given cluster.
 func (c *MetaConfig) ConfigureByCluster(cluster *v1alpha1.GreptimeDBCluster, roleSpec v1alpha1.RoleSpec) error {
-	if roleSpec.GetRoleKind() != v1alpha1.MetaComponentKind {
+	if roleSpec.GetRoleKind() != v1alpha1.MetaRoleKind {
 		return fmt.Errorf("invalid role kind: %s", roleSpec.GetRoleKind())
 	}
 
@@ -84,8 +84,8 @@ func (c *MetaConfig) ConfigureByStandalone(_ *v1alpha1.GreptimeDBStandalone) err
 }
 
 // Kind returns the component kind of the meta.
-func (c *MetaConfig) Kind() v1alpha1.ComponentKind {
-	return v1alpha1.MetaComponentKind
+func (c *MetaConfig) Kind() v1alpha1.RoleKind {
+	return v1alpha1.MetaRoleKind
 }
 
 // GetInputConfig returns the input config of the meta.

--- a/pkg/dbconfig/standalone_config.go
+++ b/pkg/dbconfig/standalone_config.go
@@ -38,11 +38,7 @@ type StandaloneConfig struct {
 }
 
 // ConfigureByCluster is not need to implement in standalone mode.
-func (c *StandaloneConfig) ConfigureByCluster(_ *v1alpha1.GreptimeDBCluster) error {
-	return nil
-}
-
-func (c *StandaloneConfig) ConfigureByFrontend(_ *v1alpha1.FrontendSpec) error {
+func (c *StandaloneConfig) ConfigureByCluster(_ *v1alpha1.GreptimeDBCluster, _ v1alpha1.RoleSpec) error {
 	return nil
 }
 

--- a/pkg/dbconfig/standalone_config.go
+++ b/pkg/dbconfig/standalone_config.go
@@ -76,8 +76,8 @@ func (c *StandaloneConfig) ConfigureByStandalone(standalone *v1alpha1.GreptimeDB
 }
 
 // Kind returns the component kind of the standalone.
-func (c *StandaloneConfig) Kind() v1alpha1.ComponentKind {
-	return v1alpha1.StandaloneKind
+func (c *StandaloneConfig) Kind() v1alpha1.RoleKind {
+	return v1alpha1.StandaloneRoleKind
 }
 
 // GetInputConfig returns the input config of the standalone.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -139,31 +139,31 @@ func NewMetricsCollector() (*MetricsCollector, error) {
 // CollectClusterPodMetrics collects pod metrics for a cluster.
 func (c *MetricsCollector) CollectClusterPodMetrics(ctx context.Context, cluster *greptimev1alpha1.GreptimeDBCluster) error {
 	if cluster.GetMeta() != nil {
-		if err := c.collectPodMetricsByRole(ctx, cluster, greptimev1alpha1.MetaComponentKind); err != nil {
+		if err := c.collectPodMetricsByRole(ctx, cluster, greptimev1alpha1.MetaRoleKind); err != nil {
 			return err
 		}
 	}
 
 	if cluster.GetDatanode() != nil {
-		if err := c.collectPodMetricsByRole(ctx, cluster, greptimev1alpha1.DatanodeComponentKind); err != nil {
+		if err := c.collectPodMetricsByRole(ctx, cluster, greptimev1alpha1.DatanodeRoleKind); err != nil {
 			return err
 		}
 	}
 
 	if cluster.GetFrontend() != nil {
-		if err := c.collectPodMetricsByRole(ctx, cluster, greptimev1alpha1.FrontendComponentKind); err != nil {
+		if err := c.collectPodMetricsByRole(ctx, cluster, greptimev1alpha1.FrontendRoleKind); err != nil {
 			return err
 		}
 	}
 
 	if cluster.GetFlownode() != nil {
-		if err := c.collectPodMetricsByRole(ctx, cluster, greptimev1alpha1.FlownodeComponentKind); err != nil {
+		if err := c.collectPodMetricsByRole(ctx, cluster, greptimev1alpha1.FlownodeRoleKind); err != nil {
 			return err
 		}
 	}
 
 	if cluster.GetFrontendGroups() != nil {
-		if err := c.collectPodMetricsByRole(ctx, cluster, greptimev1alpha1.FrontendComponentKind); err != nil {
+		if err := c.collectPodMetricsByRole(ctx, cluster, greptimev1alpha1.FrontendRoleKind); err != nil {
 			return err
 		}
 	}
@@ -171,10 +171,10 @@ func (c *MetricsCollector) CollectClusterPodMetrics(ctx context.Context, cluster
 	return nil
 }
 
-func (c *MetricsCollector) collectPodMetricsByRole(ctx context.Context, cluster *greptimev1alpha1.GreptimeDBCluster, role greptimev1alpha1.ComponentKind) error {
+func (c *MetricsCollector) collectPodMetricsByRole(ctx context.Context, cluster *greptimev1alpha1.GreptimeDBCluster, role greptimev1alpha1.RoleKind) error {
 	var podList []corev1.Pod
 
-	if role == greptimev1alpha1.FrontendComponentKind {
+	if role == greptimev1alpha1.FrontendRoleKind {
 		for _, frontend := range cluster.GetFrontendGroups() {
 			frontendPods, err := c.getPods(ctx, cluster, role, frontend.Name)
 			if err != nil {
@@ -199,7 +199,7 @@ func (c *MetricsCollector) collectPodMetricsByRole(ctx context.Context, cluster 
 	return nil
 }
 
-func (c *MetricsCollector) collectPodMetrics(ctx context.Context, clusterName string, pod *corev1.Pod, role greptimev1alpha1.ComponentKind) error {
+func (c *MetricsCollector) collectPodMetrics(ctx context.Context, clusterName string, pod *corev1.Pod, role greptimev1alpha1.RoleKind) error {
 	if pod.Status.Conditions == nil {
 		return nil
 	}
@@ -278,7 +278,7 @@ func (c *MetricsCollector) getPodConditionTime(podStatus *corev1.PodStatus, cond
 	return nil, fmt.Errorf("condition %s not found", conditionType)
 }
 
-func (c *MetricsCollector) getPods(ctx context.Context, cluster *greptimev1alpha1.GreptimeDBCluster, componentKind greptimev1alpha1.ComponentKind, additionalName string) ([]corev1.Pod, error) {
+func (c *MetricsCollector) getPods(ctx context.Context, cluster *greptimev1alpha1.GreptimeDBCluster, componentKind greptimev1alpha1.RoleKind, additionalName string) ([]corev1.Pod, error) {
 	resourceName := common.ResourceName(cluster.Name, componentKind, additionalName)
 
 	selector := metav1.LabelSelector{
@@ -299,7 +299,7 @@ func (c *MetricsCollector) getPods(ctx context.Context, cluster *greptimev1alpha
 	return pods.Items, nil
 }
 
-func (c *MetricsCollector) collectPodImagePullingDuration(ctx context.Context, clusterName string, pod *corev1.Pod, role greptimev1alpha1.ComponentKind) error {
+func (c *MetricsCollector) collectPodImagePullingDuration(ctx context.Context, clusterName string, pod *corev1.Pod, role greptimev1alpha1.RoleKind) error {
 	imageName, duration, err := c.getImagePullingDurationFromEvents(ctx, pod)
 	if errors.Is(err, ErrEmptyEvents) { // Maybe the events are deleted by the garbage collector.
 		return nil

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -279,7 +279,7 @@ func (c *MetricsCollector) getPodConditionTime(podStatus *corev1.PodStatus, cond
 }
 
 func (c *MetricsCollector) getPods(ctx context.Context, cluster *greptimev1alpha1.GreptimeDBCluster, componentKind greptimev1alpha1.ComponentKind, additionalName string) ([]corev1.Pod, error) {
-	resourceName := common.AdditionalResourceName(cluster.Name, additionalName, componentKind)
+	resourceName := common.ResourceName(cluster.Name, componentKind, additionalName)
 
 	selector := metav1.LabelSelector{
 		MatchLabels: map[string]string{

--- a/tests/e2e/greptimedbcluster/test_basic_cluster.go
+++ b/tests/e2e/greptimedbcluster/test_basic_cluster.go
@@ -63,7 +63,7 @@ func TestBasicCluster(ctx context.Context, h *helper.Helper) {
 	err = h.Get(ctx, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}, testCluster)
 	Expect(err).NotTo(HaveOccurred(), "failed to get cluster")
 	By("Execute distributed SQL test")
-	frontendAddr, err := h.PortForward(ctx, testCluster.Namespace, common.ResourceName(testCluster.Name, greptimev1alpha1.FrontendComponentKind), int(testCluster.Spec.PostgreSQLPort))
+	frontendAddr, err := h.PortForward(ctx, testCluster.Namespace, common.ResourceName(testCluster.Name, greptimev1alpha1.FrontendRoleKind), int(testCluster.Spec.PostgreSQLPort))
 	Expect(err).NotTo(HaveOccurred(), "failed to port forward frontend service")
 	Eventually(func() error {
 		conn, err := net.Dial("tcp", frontendAddr)
@@ -89,7 +89,7 @@ func TestBasicCluster(ctx context.Context, h *helper.Helper) {
 	}, helper.DefaultTimeout, time.Second).Should(HaveOccurred())
 
 	By("The PVC of the datanode should be retained")
-	datanodePVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeComponentKind, common.FileStorageTypeDatanode)
+	datanodePVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeRoleKind, common.FileStorageTypeDatanode)
 	Expect(err).NotTo(HaveOccurred(), "failed to get datanode PVCs")
 	Expect(int32(len(datanodePVCs))).To(Equal(*testCluster.Spec.Datanode.Replicas), "the number of datanode PVCs should be equal to the number of datanode replicas")
 

--- a/tests/e2e/greptimedbcluster/test_cluster_dedicated_wal.go
+++ b/tests/e2e/greptimedbcluster/test_cluster_dedicated_wal.go
@@ -64,7 +64,7 @@ func TestClusterDedicatedWAL(ctx context.Context, h *helper.Helper) {
 	Expect(err).NotTo(HaveOccurred(), "failed to get cluster")
 
 	By("Execute distributed SQL test")
-	frontendAddr, err := h.PortForward(ctx, testCluster.Namespace, common.ResourceName(testCluster.Name, greptimev1alpha1.FrontendComponentKind), int(testCluster.Spec.PostgreSQLPort))
+	frontendAddr, err := h.PortForward(ctx, testCluster.Namespace, common.ResourceName(testCluster.Name, greptimev1alpha1.FrontendRoleKind), int(testCluster.Spec.PostgreSQLPort))
 	Expect(err).NotTo(HaveOccurred(), "failed to port forward frontend service")
 	Eventually(func() error {
 		conn, err := net.Dial("tcp", frontendAddr)
@@ -90,13 +90,13 @@ func TestClusterDedicatedWAL(ctx context.Context, h *helper.Helper) {
 	}, helper.DefaultTimeout, time.Second).Should(HaveOccurred())
 
 	By("The PVC of the datanode should be retained")
-	datanodePVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeComponentKind, common.FileStorageTypeDatanode)
+	datanodePVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeRoleKind, common.FileStorageTypeDatanode)
 	Expect(err).NotTo(HaveOccurred(), "failed to get datanode PVCs")
 	Expect(int32(len(datanodePVCs))).To(Equal(*testCluster.Spec.Datanode.Replicas), "the number of datanode PVCs should be equal to the number of datanode replicas")
 
 	By("The PVC of the WAL should be deleted")
 	Eventually(func() error {
-		walPVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeComponentKind, common.FileStorageTypeWAL)
+		walPVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeRoleKind, common.FileStorageTypeWAL)
 		if err != nil {
 			return err
 		}

--- a/tests/e2e/greptimedbcluster/test_cluster_enable_flow.go
+++ b/tests/e2e/greptimedbcluster/test_cluster_enable_flow.go
@@ -64,7 +64,7 @@ func TestClusterEnableFlow(ctx context.Context, h *helper.Helper) {
 	Expect(err).NotTo(HaveOccurred(), "failed to get cluster")
 
 	By("Execute distributed SQL test")
-	frontendAddr, err := h.PortForward(ctx, testCluster.Namespace, common.ResourceName(testCluster.Name, greptimev1alpha1.FrontendComponentKind), int(testCluster.Spec.PostgreSQLPort))
+	frontendAddr, err := h.PortForward(ctx, testCluster.Namespace, common.ResourceName(testCluster.Name, greptimev1alpha1.FrontendRoleKind), int(testCluster.Spec.PostgreSQLPort))
 	Expect(err).NotTo(HaveOccurred(), "failed to port forward frontend service")
 	Eventually(func() error {
 		conn, err := net.Dial("tcp", frontendAddr)
@@ -90,7 +90,7 @@ func TestClusterEnableFlow(ctx context.Context, h *helper.Helper) {
 	}, helper.DefaultTimeout, time.Second).Should(HaveOccurred())
 
 	By("The PVC of the datanode should be retained")
-	datanodePVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeComponentKind, common.FileStorageTypeDatanode)
+	datanodePVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeRoleKind, common.FileStorageTypeDatanode)
 	Expect(err).NotTo(HaveOccurred(), "failed to get datanode PVCs")
 	Expect(int32(len(datanodePVCs))).To(Equal(*testCluster.Spec.Datanode.Replicas), "the number of datanode PVCs should be equal to the number of datanode replicas")
 

--- a/tests/e2e/greptimedbcluster/test_cluster_enable_monitoring.go
+++ b/tests/e2e/greptimedbcluster/test_cluster_enable_monitoring.go
@@ -68,7 +68,7 @@ func TestClusterEnableMonitoring(ctx context.Context, h *helper.Helper) {
 	Expect(err).NotTo(HaveOccurred(), "failed to get cluster")
 
 	By("Execute distributed SQL test")
-	frontendAddr, err := h.PortForward(ctx, testCluster.Namespace, common.ResourceName(testCluster.Name, greptimev1alpha1.FrontendComponentKind), int(testCluster.Spec.PostgreSQLPort))
+	frontendAddr, err := h.PortForward(ctx, testCluster.Namespace, common.ResourceName(testCluster.Name, greptimev1alpha1.FrontendRoleKind), int(testCluster.Spec.PostgreSQLPort))
 	Expect(err).NotTo(HaveOccurred(), "failed to port forward frontend service")
 	Eventually(func() error {
 		conn, err := net.Dial("tcp", frontendAddr)
@@ -82,7 +82,7 @@ func TestClusterEnableMonitoring(ctx context.Context, h *helper.Helper) {
 	err = h.RunSQLTest(ctx, frontendAddr, testSQLFile)
 	Expect(err).NotTo(HaveOccurred(), "failed to run sql test")
 
-	monitoringAddr, err := h.PortForward(ctx, testCluster.Namespace, common.ResourceName(common.MonitoringServiceName(testCluster.Name), greptimev1alpha1.StandaloneKind), int(testCluster.Spec.PostgreSQLPort))
+	monitoringAddr, err := h.PortForward(ctx, testCluster.Namespace, common.ResourceName(common.MonitoringServiceName(testCluster.Name), greptimev1alpha1.StandaloneRoleKind), int(testCluster.Spec.PostgreSQLPort))
 	Expect(err).NotTo(HaveOccurred(), "failed to port forward monitoring service")
 	Eventually(func() error {
 		conn, err := net.Dial("tcp", monitoringAddr)
@@ -130,7 +130,7 @@ func TestClusterEnableMonitoring(ctx context.Context, h *helper.Helper) {
 	}, helper.DefaultTimeout, time.Second).Should(HaveOccurred())
 
 	By("The PVC of the datanode should be retained")
-	datanodePVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeComponentKind, common.FileStorageTypeDatanode)
+	datanodePVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeRoleKind, common.FileStorageTypeDatanode)
 	Expect(err).NotTo(HaveOccurred(), "failed to get datanode PVCs")
 	Expect(int32(len(datanodePVCs))).To(Equal(*testCluster.Spec.Datanode.Replicas), "the number of datanode PVCs should be equal to the number of datanode replicas")
 

--- a/tests/e2e/greptimedbcluster/test_cluster_enable_remote_wal.go
+++ b/tests/e2e/greptimedbcluster/test_cluster_enable_remote_wal.go
@@ -64,7 +64,7 @@ func TestClusterEnableRemoteWal(ctx context.Context, h *helper.Helper) {
 	Expect(err).NotTo(HaveOccurred(), "failed to get cluster")
 
 	By("Execute distributed SQL test")
-	frontendAddr, err := h.PortForward(ctx, testCluster.Namespace, common.ResourceName(testCluster.Name, greptimev1alpha1.FrontendComponentKind), int(testCluster.Spec.PostgreSQLPort))
+	frontendAddr, err := h.PortForward(ctx, testCluster.Namespace, common.ResourceName(testCluster.Name, greptimev1alpha1.FrontendRoleKind), int(testCluster.Spec.PostgreSQLPort))
 	Expect(err).NotTo(HaveOccurred(), "failed to port forward frontend service")
 	Eventually(func() error {
 		conn, err := net.Dial("tcp", frontendAddr)
@@ -90,7 +90,7 @@ func TestClusterEnableRemoteWal(ctx context.Context, h *helper.Helper) {
 	}, helper.DefaultTimeout, time.Second).Should(HaveOccurred())
 
 	By("The PVC of the datanode should be retained")
-	datanodePVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeComponentKind, common.FileStorageTypeDatanode)
+	datanodePVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeRoleKind, common.FileStorageTypeDatanode)
 	Expect(err).NotTo(HaveOccurred(), "failed to get datanode PVCs")
 	Expect(int32(len(datanodePVCs))).To(Equal(*testCluster.Spec.Datanode.Replicas), "the number of datanode PVCs should be equal to the number of datanode replicas")
 

--- a/tests/e2e/greptimedbcluster/test_cluster_frontend_groups.go
+++ b/tests/e2e/greptimedbcluster/test_cluster_frontend_groups.go
@@ -78,7 +78,7 @@ func TestClusterFrontendGroups(ctx context.Context, h *helper.Helper) {
 		writeFrontendName = frontendGroups[1].GetName()
 	)
 
-	frontendAddr, err := h.PortForward(ctx, testCluster.Namespace, common.ResourceName(testCluster.Name, greptimev1alpha1.FrontendComponentKind, writeFrontendName), int(testCluster.Spec.PostgreSQLPort))
+	frontendAddr, err := h.PortForward(ctx, testCluster.Namespace, common.ResourceName(testCluster.Name, greptimev1alpha1.FrontendRoleKind, writeFrontendName), int(testCluster.Spec.PostgreSQLPort))
 	Expect(err).NotTo(HaveOccurred(), "failed to port forward frontend service")
 	Eventually(func() error {
 		conn, err := net.Dial("tcp", frontendAddr)
@@ -92,7 +92,7 @@ func TestClusterFrontendGroups(ctx context.Context, h *helper.Helper) {
 	err = h.RunSQLTest(ctx, frontendAddr, testWriteSQLFile)
 	Expect(err).NotTo(HaveOccurred(), "failed to run sql test")
 
-	frontendAddr, err = h.PortForward(ctx, testCluster.Namespace, common.ResourceName(testCluster.Name, greptimev1alpha1.FrontendComponentKind, readFrontendName), int(testCluster.Spec.PostgreSQLPort))
+	frontendAddr, err = h.PortForward(ctx, testCluster.Namespace, common.ResourceName(testCluster.Name, greptimev1alpha1.FrontendRoleKind, readFrontendName), int(testCluster.Spec.PostgreSQLPort))
 	Expect(err).NotTo(HaveOccurred(), "failed to port forward frontend service")
 	Eventually(func() error {
 		conn, err := net.Dial("tcp", frontendAddr)
@@ -118,7 +118,7 @@ func TestClusterFrontendGroups(ctx context.Context, h *helper.Helper) {
 	}, helper.DefaultTimeout, time.Second).Should(HaveOccurred())
 
 	By("The PVC of the datanode should be retained")
-	datanodePVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeComponentKind, common.FileStorageTypeDatanode)
+	datanodePVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeRoleKind, common.FileStorageTypeDatanode)
 	Expect(err).NotTo(HaveOccurred(), "failed to get datanode PVCs")
 	Expect(int32(len(datanodePVCs))).To(Equal(*testCluster.Spec.Datanode.Replicas), "the number of datanode PVCs should be equal to the number of datanode replicas")
 

--- a/tests/e2e/greptimedbcluster/test_cluster_frontend_groups.go
+++ b/tests/e2e/greptimedbcluster/test_cluster_frontend_groups.go
@@ -78,7 +78,7 @@ func TestClusterFrontendGroups(ctx context.Context, h *helper.Helper) {
 		writeFrontendName = frontendGroups[1].GetName()
 	)
 
-	frontendAddr, err := h.PortForward(ctx, testCluster.Namespace, common.AdditionalResourceName(testCluster.Name, writeFrontendName, greptimev1alpha1.FrontendComponentKind), int(testCluster.Spec.PostgreSQLPort))
+	frontendAddr, err := h.PortForward(ctx, testCluster.Namespace, common.ResourceName(testCluster.Name, greptimev1alpha1.FrontendComponentKind, writeFrontendName), int(testCluster.Spec.PostgreSQLPort))
 	Expect(err).NotTo(HaveOccurred(), "failed to port forward frontend service")
 	Eventually(func() error {
 		conn, err := net.Dial("tcp", frontendAddr)
@@ -92,7 +92,7 @@ func TestClusterFrontendGroups(ctx context.Context, h *helper.Helper) {
 	err = h.RunSQLTest(ctx, frontendAddr, testWriteSQLFile)
 	Expect(err).NotTo(HaveOccurred(), "failed to run sql test")
 
-	frontendAddr, err = h.PortForward(ctx, testCluster.Namespace, common.AdditionalResourceName(testCluster.Name, readFrontendName, greptimev1alpha1.FrontendComponentKind), int(testCluster.Spec.PostgreSQLPort))
+	frontendAddr, err = h.PortForward(ctx, testCluster.Namespace, common.ResourceName(testCluster.Name, greptimev1alpha1.FrontendComponentKind, readFrontendName), int(testCluster.Spec.PostgreSQLPort))
 	Expect(err).NotTo(HaveOccurred(), "failed to port forward frontend service")
 	Eventually(func() error {
 		conn, err := net.Dial("tcp", frontendAddr)

--- a/tests/e2e/greptimedbcluster/test_cluster_frontend_groups_ingress.go
+++ b/tests/e2e/greptimedbcluster/test_cluster_frontend_groups_ingress.go
@@ -105,7 +105,7 @@ func TestClusterFrontendGroupsIngress(ctx context.Context, h *helper.Helper) {
 	}, helper.DefaultTimeout, time.Second).Should(HaveOccurred())
 
 	By("The PVC of the datanode should be retained")
-	datanodePVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeComponentKind, common.FileStorageTypeDatanode)
+	datanodePVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeRoleKind, common.FileStorageTypeDatanode)
 	Expect(err).NotTo(HaveOccurred(), "failed to get datanode PVCs")
 	Expect(int32(len(datanodePVCs))).To(Equal(*testCluster.Spec.Datanode.Replicas), "the number of datanode PVCs should be equal to the number of datanode replicas")
 

--- a/tests/e2e/greptimedbcluster/test_cluster_frontend_ingress.go
+++ b/tests/e2e/greptimedbcluster/test_cluster_frontend_ingress.go
@@ -93,7 +93,7 @@ func TestClusterFrontendIngress(ctx context.Context, h *helper.Helper) {
 	}, helper.DefaultTimeout, time.Second).Should(HaveOccurred())
 
 	By("The PVC of the datanode should be retained")
-	datanodePVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeComponentKind, common.FileStorageTypeDatanode)
+	datanodePVCs, err := h.GetPVCs(ctx, testCluster.Namespace, testCluster.Name, greptimev1alpha1.DatanodeRoleKind, common.FileStorageTypeDatanode)
 	Expect(err).NotTo(HaveOccurred(), "failed to get datanode PVCs")
 	Expect(int32(len(datanodePVCs))).To(Equal(*testCluster.Spec.Datanode.Replicas), "the number of datanode PVCs should be equal to the number of datanode replicas")
 

--- a/tests/e2e/greptimedbcluster/test_scale_cluster.go
+++ b/tests/e2e/greptimedbcluster/test_scale_cluster.go
@@ -65,7 +65,7 @@ func TestScaleCluster(ctx context.Context, h *helper.Helper) {
 	Expect(err).NotTo(HaveOccurred(), "failed to get cluster")
 
 	By("Execute distributed SQL test")
-	frontendAddr, err := h.PortForward(ctx, testCluster.Namespace, common.ResourceName(testCluster.Name, greptimev1alpha1.FrontendComponentKind), int(testCluster.Spec.PostgreSQLPort))
+	frontendAddr, err := h.PortForward(ctx, testCluster.Namespace, common.ResourceName(testCluster.Name, greptimev1alpha1.FrontendRoleKind), int(testCluster.Spec.PostgreSQLPort))
 	Expect(err).NotTo(HaveOccurred(), "failed to port forward frontend service")
 	Eventually(func() error {
 		conn, err := net.Dial("tcp", frontendAddr)

--- a/tests/e2e/greptimedbstandalone/test_basic_standalone.go
+++ b/tests/e2e/greptimedbstandalone/test_basic_standalone.go
@@ -64,7 +64,7 @@ func TestBasicStandalone(ctx context.Context, h *helper.Helper) {
 	Expect(err).NotTo(HaveOccurred(), "failed to get standalone")
 
 	By("Run SQL test")
-	frontendAddr, err := h.PortForward(ctx, testStandalone.Namespace, common.ResourceName(testStandalone.Name, greptimev1alpha1.StandaloneKind), int(testStandalone.Spec.PostgreSQLPort))
+	frontendAddr, err := h.PortForward(ctx, testStandalone.Namespace, common.ResourceName(testStandalone.Name, greptimev1alpha1.StandaloneRoleKind), int(testStandalone.Spec.PostgreSQLPort))
 	Expect(err).NotTo(HaveOccurred(), "failed to port forward frontend service")
 	Eventually(func() error {
 		conn, err := net.Dial("tcp", frontendAddr)
@@ -90,7 +90,7 @@ func TestBasicStandalone(ctx context.Context, h *helper.Helper) {
 	}, helper.DefaultTimeout, time.Second).Should(HaveOccurred())
 
 	By("The PVC of the database should be retained")
-	dataPVCs, err := h.GetPVCs(ctx, testStandalone.Namespace, testStandalone.Name, greptimev1alpha1.StandaloneKind, common.FileStorageTypeDatanode)
+	dataPVCs, err := h.GetPVCs(ctx, testStandalone.Namespace, testStandalone.Name, greptimev1alpha1.StandaloneRoleKind, common.FileStorageTypeDatanode)
 	Expect(err).NotTo(HaveOccurred(), "failed to get data PVCs")
 	Expect(len(dataPVCs)).To(Equal(1), "the number of datanode PVCs should be equal to 1")
 

--- a/tests/e2e/helper/helper.go
+++ b/tests/e2e/helper/helper.go
@@ -178,7 +178,7 @@ func (h *Helper) GetPhase(ctx context.Context, namespace, name string, object cl
 }
 
 // GetPVCs returns the PVC list of the given component.
-func (h *Helper) GetPVCs(ctx context.Context, namespace, name string, kind greptimev1alpha1.ComponentKind, fsType common.FileStorageType) ([]corev1.PersistentVolumeClaim, error) {
+func (h *Helper) GetPVCs(ctx context.Context, namespace, name string, kind greptimev1alpha1.RoleKind, fsType common.FileStorageType) ([]corev1.PersistentVolumeClaim, error) {
 	return common.GetPVCs(ctx, h.Client, namespace, name, kind, fsType)
 }
 


### PR DESCRIPTION
## What's changed

1. Add `RoleSpec` interface and use in `dbConfig.Config` interface;
2. Clean the code in `deployers/common`;
3. Use naming like `*RoleKind*` instead of `*ComponentKind*` keep consistent with greptimedb convention;