### PR TITLE
chore: bump golang lint version to v2.1.6

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,56 +1,39 @@
+version: "2"
+
 # Options for analysis running.
 run:
-  # Timeout for analysis, e.g. 30s, 5m.
-  # Default: 1m
+  # Timeout for running analysis (default: 1m, set to 10m here)
   timeout: 10m
 
   # The default concurrency value is the number of available CPU.
   concurrency: 4
 
-  # Which dirs to skip: issues from them won't be reported.
-  # Can use regexp here: `generated.*`, regexp is applied on full path,
-  # including the path prefix if one is set.
-  # Default value is empty list,
-  # but default dirs are skipped independently of this option's value (see skip-dirs-use-default).
-  # "/" will be replaced by current OS file path separator to properly work on Windows.
-  skip-dirs:
-    - bin
-    - docs
-    - examples
-    - hack
-
 # output configuration options.
 output:
-  # Format: colored-line-number|line-number|json|colored-tab|tab|checkstyle|code-climate|junit-xml|github-actions|teamcity
-  #
-  # Multiple can be specified by separating them by comma, output can be provided
-  # for each of them by separating format name and path by colon symbol.
-  # Output path can be either `stdout`, `stderr` or path to the file to write to.
-  # Example: "checkstyle:report.xml,json:stdout,colored-line-number"
-  #
-  # Default: colored-line-number
-  format: colored-line-number
-
-  # Print lines of code with issue.
-  # Default: true
-  print-issued-lines: true
-
-  # Print linter name in the end of issue text.
-  # Default: true
-  print-linter-lines: true
+  formats:
+    text:
+      path: stdout
+      colors: true
+      print-issued-lines: true
+      print-linter-name: true
 
 linters:
   # Disable all linters.
-  disable-all: true
+  default: none
+
+  # Directories to skip during analysis.
+  exclusions:
+    paths:
+      - bin
+      - docs
+      - examples
+      - hack
 
   # Enable specific linter
   # https://golangci-lint.run/usage/linters/#enabled-by-default
   enable:
     # Errcheck is a program for checking for unchecked errors in Go code. These unchecked errors can be critical bugs in some cases.
     - errcheck
-
-    # Linter for Go source code that specializes in simplifying code.
-    - gosimple
 
     # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string.
     - govet
@@ -62,9 +45,6 @@ linters:
     # The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint.
     - staticcheck
 
-    # Check import statements are formatted according to the 'goimport' command. Reformat imports in autofix mode.
-    - goimports
-
     # Checks whether HTTP response body is closed successfully.
     - bodyclose
 
@@ -72,9 +52,6 @@ linters:
     # Extensible without recompilation through dynamic rules.
     # Dynamic rules are written declaratively with AST patterns, filters, report message and optional suggestion.
     - gocritic
-
-    # Gofmt checks whether code was gofmt-ed. By default, this tool runs with -s option to check for code simplification.
-    - gofmt
 
     # Finds repeated strings that could be replaced by a constant.
     - goconst
@@ -85,15 +62,86 @@ linters:
     # Finds naked returns in functions greater than a specified function length.
     - nakedret
 
-linters-settings:
-  nakedret:
-    # Make an issue if func has more lines of code than this setting, and it has naked returns.
-    # Default: 30
-    max-func-lines: 50
-  goimports:
-    # A comma-separated list of prefixes, which, if set, checks import paths
-    # with the given prefixes are grouped after 3rd-party packages.
-    # Default: ""
-    local-prefixes: github.com/GreptimeTeam/greptimedb-operator
-  linters-settings:
-    min-occurrences: 3
+  settings:
+    errcheck:
+      # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
+      # Such cases aren't reported by default.
+      # Default: false
+      check-type-assertions: false
+
+      # List of functions to exclude from checking, where each entry is a single function to exclude.
+      # See https://github.com/kisielk/errcheck#excluding-functions for details.
+      exclude-functions:
+        # IO
+        - (io.Closer).Close
+        - (*os.File).Close
+
+        # Network
+        - (net.Conn).Close
+        - (net.Listener).Close
+
+        # Database
+        - (*database/sql.DB).Close
+        - (*database/sql.Rows).Close
+        - (*database/sql.Conn).Close
+        - (*github.com/jackc/pgx/v5.Conn).Close
+
+        # HTTP
+        - (*net/http.Response).Body.Close
+        - (*mime/multipart.Writer).Close
+
+        # ThirdParty
+        - (*go.etcd.io/etcd/client/v3.Client).Close
+
+      # Display function signature instead of selector.
+      # Default: false
+      verbose: true
+
+    staticcheck:
+      # https://staticcheck.dev/docs/configuration/options/#dot_import_whitelist
+      # Default: ["github.com/mmcloughlin/avo/build", "github.com/mmcloughlin/avo/operand", "github.com/mmcloughlin/avo/reg"]
+      dot-import-whitelist:
+        - github.com/onsi/gomega
+        - github.com/onsi/ginkgo/v2
+      # SAxxxx checks in https://staticcheck.dev/docs/configuration/options/#checks
+      # Example (to disable some checks): [ "all", "-SA1000", "-SA1001"]
+      # Default: ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022"]
+      checks:
+        - "all"
+        # Incorrect or missing package comment.
+        # https://staticcheck.dev/docs/checks/#ST1000
+        - "-ST1000"
+        # Poorly chosen identifier.
+        # https://staticcheck.dev/docs/checks/#ST1003
+        - "-ST1003"
+        # Poorly chosen receiver name.
+        # https://staticcheck.dev/docs/checks/#ST1006
+        - "-ST1006"
+        # Use consistent method receiver names.
+        # https://staticcheck.dev/docs/checks/#ST1016
+        - "-ST1016"
+        # The documentation of an exported function should start with the function's name.
+        # https://staticcheck.dev/docs/checks/#ST1020
+        - "-ST1020"
+        # The documentation of an exported type should start with type's name.
+        # https://staticcheck.dev/docs/checks/#ST1021
+        - "-ST1021"
+        # The documentation of an exported variable or constant should start with variable's name.
+        # https://staticcheck.dev/docs/checks/#ST1022
+        - "-ST1022"
+
+    nakedret:
+      # Make an issue if func has more lines of code than this setting, and it has naked returns.
+      # Default: 30
+      max-func-lines: 50
+    goconst:
+      # Minimum number of occurrences to suggest converting to constant (default: 3)
+      min-occurrences: 3
+
+formatters:
+  enable:
+    # Gofmt checks whether code was gofmt-ed. By default, this tool runs with -s option to check for code simplification.
+    - gofmt
+
+    # Handles imports addition/removal (relies on gci for grouping)
+    - goimports

--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ CRD_REF_DOCS ?= $(LOCALBIN)/crd-ref-docs
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
 CRD_REF_DOCS_VERSION ?= v0.1.0
-GOLANGCI_LINT_VERSION ?= v1.60.0
+GOLANGCI_LINT_VERSION ?= v2.1.6
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -268,7 +268,7 @@ $(ENVTEST): $(LOCALBIN)
 
 .PHONY: golangci-lint
 golangci-lint: ## Install golangci-lint.
-	GOBIN=$(LOCALBIN) GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
+	GOBIN=$(LOCALBIN) GO111MODULE=on go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
 
 .PHONY: crd-ref-docs
 crd-ref-docs: ## Install crd-ref-docs.

--- a/controllers/greptimedbcluster/controller.go
+++ b/controllers/greptimedbcluster/controller.go
@@ -137,7 +137,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}()
 
 	// The object is being deleted.
-	if !cluster.ObjectMeta.DeletionTimestamp.IsZero() {
+	if !cluster.DeletionTimestamp.IsZero() {
 		return r.delete(ctx, cluster)
 	}
 

--- a/controllers/greptimedbcluster/deployers/datanode.go
+++ b/controllers/greptimedbcluster/deployers/datanode.go
@@ -164,7 +164,7 @@ func (d *DatanodeDeployer) Apply(ctx context.Context, crdObject client.Object, o
 						return err
 					}
 				}
-				if err := d.Client.Patch(ctx, newObject, client.MergeFrom(oldObject)); err != nil {
+				if err := d.Patch(ctx, newObject, client.MergeFrom(oldObject)); err != nil {
 					return err
 				}
 				updateObject = true
@@ -474,7 +474,7 @@ func (b *datanodeBuilder) generatePodTemplateSpec() corev1.PodTemplateSpec {
 	}
 
 	podTemplateSpec.Spec.InitContainers = append(podTemplateSpec.Spec.InitContainers, *b.generateInitializer())
-	podTemplateSpec.ObjectMeta.Labels = util.MergeStringMap(podTemplateSpec.ObjectMeta.Labels, map[string]string{
+	podTemplateSpec.Labels = util.MergeStringMap(podTemplateSpec.Labels, map[string]string{
 		constant.GreptimeDBComponentName: common.ResourceName(b.Cluster.Name, b.RoleKind),
 	})
 

--- a/controllers/greptimedbcluster/deployers/flownode.go
+++ b/controllers/greptimedbcluster/deployers/flownode.go
@@ -279,7 +279,7 @@ func (b *flownodeBuilder) generatePodTemplateSpec() corev1.PodTemplateSpec {
 	}
 
 	podTemplateSpec.Spec.InitContainers = append(podTemplateSpec.Spec.InitContainers, *b.generateInitializer())
-	podTemplateSpec.ObjectMeta.Labels = util.MergeStringMap(podTemplateSpec.ObjectMeta.Labels, map[string]string{
+	podTemplateSpec.Labels = util.MergeStringMap(podTemplateSpec.Labels, map[string]string{
 		constant.GreptimeDBComponentName: common.ResourceName(b.Cluster.Name, b.RoleKind),
 	})
 

--- a/controllers/greptimedbcluster/deployers/frontend.go
+++ b/controllers/greptimedbcluster/deployers/frontend.go
@@ -443,7 +443,7 @@ func (b *frontendBuilder) generatePodTemplateSpec(frontend *v1alpha1.FrontendSpe
 	if len(frontend.GetName()) != 0 {
 		resourceName = common.ResourceName(b.Cluster.Name, b.RoleKind, frontend.GetName())
 	}
-	podTemplateSpec.ObjectMeta.Labels = util.MergeStringMap(podTemplateSpec.ObjectMeta.Labels, map[string]string{
+	podTemplateSpec.Labels = util.MergeStringMap(podTemplateSpec.Labels, map[string]string{
 		constant.GreptimeDBComponentName: resourceName,
 	})
 

--- a/controllers/greptimedbcluster/deployers/meta.go
+++ b/controllers/greptimedbcluster/deployers/meta.go
@@ -344,7 +344,7 @@ func (b *metaBuilder) generatePodTemplateSpec() *corev1.PodTemplateSpec {
 		b.AddVectorSidecar(podTemplateSpec, v1alpha1.MetaRoleKind)
 	}
 
-	podTemplateSpec.ObjectMeta.Labels = util.MergeStringMap(podTemplateSpec.ObjectMeta.Labels, map[string]string{
+	podTemplateSpec.Labels = util.MergeStringMap(podTemplateSpec.Labels, map[string]string{
 		constant.GreptimeDBComponentName: common.ResourceName(b.Cluster.Name, b.RoleKind),
 	})
 

--- a/controllers/greptimedbstandalone/controller.go
+++ b/controllers/greptimedbstandalone/controller.go
@@ -104,7 +104,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}()
 
 	// The object is being deleted.
-	if !standalone.ObjectMeta.DeletionTimestamp.IsZero() {
+	if !standalone.DeletionTimestamp.IsZero() {
 		return r.delete(ctx, standalone)
 	}
 

--- a/controllers/greptimedbstandalone/deployer.go
+++ b/controllers/greptimedbstandalone/deployer.go
@@ -290,7 +290,7 @@ func (b *standaloneBuilder) generatePodTemplateSpec() corev1.PodTemplateSpec {
 	b.addVolumeMounts(template)
 
 	template.Spec.Containers[constant.MainContainerIndex].Ports = b.containerPorts()
-	template.ObjectMeta.Labels = util.MergeStringMap(template.ObjectMeta.Labels, map[string]string{
+	template.Labels = util.MergeStringMap(template.Labels, map[string]string{
 		constant.GreptimeDBComponentName: common.ResourceName(b.standalone.Name, v1alpha1.StandaloneRoleKind),
 	})
 

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
@@ -260,7 +259,7 @@ func (s *Server) getCluster(c *gin.Context) {
 	var cluster greptimev1alpha1.GreptimeDBCluster
 	err := s.Get(c, client.ObjectKey{Namespace: namespace, Name: name}, &cluster)
 
-	if errors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		c.JSON(http.StatusNotFound, Response{
 			Success: true,
 			Message: fmt.Sprintf("cluster '%s' is not found in namespace '%s'", name, namespace),

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -128,7 +128,7 @@ func (d *DefaultDeployer) Apply(ctx context.Context, _ client.Object, objects []
 			// If the spec or labels is not equal, update the object.
 			if !specEqual || !labelsEqual {
 				newObject.SetResourceVersion(oldObject.GetResourceVersion())
-				if err := d.Client.Patch(ctx, newObject, client.MergeFrom(oldObject)); err != nil {
+				if err := d.Patch(ctx, newObject, client.MergeFrom(oldObject)); err != nil {
 					return err
 				}
 				updateObject = true

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -239,7 +239,7 @@ func (c *MetricsCollector) collectPodMetrics(ctx context.Context, clusterName st
 	// Collect container startup and ready duration.
 	for _, container := range pod.Status.ContainerStatuses {
 		// The calculation is: pod.Status.ContainerStatuses[*].State.Running.StartedAt - pod.Status.Conditions[corev1.PodInitialized].LastTransitionTime.Time.
-		startupDuration := container.State.Running.StartedAt.Time.Sub(*initializedTime)
+		startupDuration := container.State.Running.StartedAt.Sub(*initializedTime)
 		podContainerStartupDuration.WithLabelValues(
 			pod.Namespace, clusterName, pod.Name, container.Name, pod.Spec.NodeName, string(role),
 		).Observe(startupDuration.Seconds())


### PR DESCRIPTION
Use latest version: https://github.com/golangci/golangci-lint/releases/tag/v2.1.6

v1 -> v2 configuration migrate refer to: https://golangci-lint.run/product/migration-guide/