### PR TITLE
refactor: turn on maintenance mode when cluster is starting

### DIFF
--- a/apis/v1alpha1/greptimedbcluster_types.go
+++ b/apis/v1alpha1/greptimedbcluster_types.go
@@ -861,6 +861,9 @@ type MetaStatus struct {
 	// EtcdEndpoints is the endpoints of the etcd cluster.
 	// +optional
 	EtcdEndpoints []string `json:"etcdEndpoints,omitempty"`
+
+	// MaintenanceMode is the maintenance mode of the meta.
+	MaintenanceMode bool `json:"maintenanceMode"`
 }
 
 // DatanodeStatus is the status of datanode node.

--- a/config/crd/resources/greptime.io_greptimedbclusters.yaml
+++ b/config/crd/resources/greptime.io_greptimedbclusters.yaml
@@ -22065,6 +22065,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  maintenanceMode:
+                    type: boolean
                   readyReplicas:
                     format: int32
                     type: integer
@@ -22072,6 +22074,7 @@ spec:
                     format: int32
                     type: integer
                 required:
+                - maintenanceMode
                 - readyReplicas
                 - replicas
                 type: object

--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -318,14 +318,14 @@ func SetMaintenanceMode(metaHTTPServiceURL string, enabled bool) error {
 	requestURL := fmt.Sprintf("%s/admin/maintenance?enable=%v", metaHTTPServiceURL, enabled)
 
 	operation := func() error {
-		rsp, err := http.Post(requestURL, "", nil)
+		rsp, err := http.Get(requestURL)
 		if err != nil {
 			return err
 		}
 		defer rsp.Body.Close()
 
 		if rsp.StatusCode != http.StatusOK {
-			return fmt.Errorf("failed to request metasrv '%s' for set maintenance mode '%v', status code: %d", metaHTTPServiceURL, enabled, rsp.StatusCode)
+			return fmt.Errorf("failed to request metasrv '%s' for set maintenance mode '%v', status code: %d", requestURL, enabled, rsp.StatusCode)
 		}
 
 		return nil

--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -318,7 +318,7 @@ func SetMaintenanceMode(metaHTTPServiceURL string, enabled bool) error {
 	requestURL := fmt.Sprintf("%s/admin/maintenance?enable=%v", metaHTTPServiceURL, enabled)
 
 	operation := func() error {
-		rsp, err := http.Get(requestURL)
+		rsp, err := http.Post(requestURL, "", nil)
 		if err != nil {
 			return err
 		}

--- a/controllers/greptimedbcluster/controller.go
+++ b/controllers/greptimedbcluster/controller.go
@@ -78,7 +78,7 @@ func Setup(mgr ctrl.Manager, o *options.Options) error {
 	// sync will execute the sync logic of multiple deployers in order.
 	reconciler.Deployers = []deployer.Deployer{
 		deployers.NewMonitoringDeployer(mgr),
-		deployers.NewMetaDeployer(mgr),
+		deployers.NewMetaDeployer(mgr, deployers.WithMaintenanceModeWhenCreateCluster(true)),
 		deployers.NewDatanodeDeployer(mgr),
 		deployers.NewFrontendDeployer(mgr),
 		deployers.NewFlownodeDeployer(mgr),

--- a/controllers/greptimedbcluster/deployers/datanode.go
+++ b/controllers/greptimedbcluster/deployers/datanode.go
@@ -17,7 +17,6 @@ package deployers
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"path"
 	"reflect"
 
@@ -196,7 +195,8 @@ func (d *DatanodeDeployer) turnOnMaintenanceMode(ctx context.Context, newSts *ap
 
 	if !d.maintenanceMode && d.isOldPodRestart(*newSts, *oldSts) {
 		klog.Infof("Turn on maintenance mode for datanode, statefulset: %s", newSts.Name)
-		if err := d.requestMetasrvForMaintenance(cluster, true); err != nil {
+		// FIXME(zyy17): Should record the maintenance mode in the status.
+		if err := common.SetMaintenanceMode(common.GetMetaHTTPServiceURL(cluster), true); err != nil {
 			return err
 		}
 		d.maintenanceMode = true
@@ -213,26 +213,13 @@ func (d *DatanodeDeployer) turnOffMaintenanceMode(ctx context.Context, crdObject
 
 	if d.maintenanceMode && d.shouldUseMaintenanceMode(cluster) {
 		klog.Infof("Turn off maintenance mode for datanode, cluster: %s", cluster.Name)
-		if err := d.requestMetasrvForMaintenance(cluster, false); err != nil {
+		// FIXME(zyy17): Should record the maintenance mode in the status.
+		if err := common.SetMaintenanceMode(common.GetMetaHTTPServiceURL(cluster), false); err != nil {
 			return err
 		}
 		d.maintenanceMode = false
 	}
 
-	return nil
-}
-
-func (d *DatanodeDeployer) requestMetasrvForMaintenance(cluster *v1alpha1.GreptimeDBCluster, enabled bool) error {
-	requestURL := fmt.Sprintf("http://%s.%s:%d/admin/maintenance?enable=%v", common.ResourceName(cluster.GetName(), v1alpha1.MetaRoleKind), cluster.GetNamespace(), cluster.Spec.Meta.RPCPort, enabled)
-	rsp, err := http.Get(requestURL)
-	if err != nil {
-		return err
-	}
-	defer rsp.Body.Close()
-
-	if rsp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to turn off maintenance mode for datanode, status code: %d", rsp.StatusCode)
-	}
 	return nil
 }
 

--- a/controllers/greptimedbcluster/deployers/meta.go
+++ b/controllers/greptimedbcluster/deployers/meta.go
@@ -50,6 +50,9 @@ type MetaDeployer struct {
 	*CommonDeployer
 
 	etcdMaintenanceBuilder func(etcdEndpoints []string) (clientv3.Maintenance, error)
+
+	// If true, the meta will be in maintenance mode when creating cluster.
+	maintenanceModeWhenCreateCluster bool
 }
 
 type MetaDeployerOption func(*MetaDeployer)
@@ -72,6 +75,12 @@ func NewMetaDeployer(mgr ctrl.Manager, opts ...MetaDeployerOption) *MetaDeployer
 func WithEtcdMaintenanceBuilder(builder EtcdMaintenanceBuilder) func(*MetaDeployer) {
 	return func(d *MetaDeployer) {
 		d.etcdMaintenanceBuilder = builder
+	}
+}
+
+func WithMaintenanceModeWhenCreateCluster(maintenanceModeWhenCreateCluster bool) func(*MetaDeployer) {
+	return func(d *MetaDeployer) {
+		d.maintenanceModeWhenCreateCluster = maintenanceModeWhenCreateCluster
 	}
 }
 
@@ -132,7 +141,13 @@ func (d *MetaDeployer) CheckAndUpdateStatus(ctx context.Context, highLevelObject
 
 	ready := k8sutil.IsDeploymentReady(deployment)
 
-	if cluster.Status.ClusterPhase == v1alpha1.PhaseStarting && ready && !cluster.Status.Meta.MaintenanceMode {
+	// It should meet the following conditions to turn on maintenance mode:
+	// 1. The cluster is in starting phase that means the cluster is in the process of being created.
+	// 2. The meta deployment is ready and the maintenance mode is not enabled.
+	// 3. The `maintenanceModeWhenCreateCluster` is true in meta deployer options.
+	if d.maintenanceModeWhenCreateCluster &&
+		cluster.Status.ClusterPhase == v1alpha1.PhaseStarting &&
+		ready && !cluster.Status.Meta.MaintenanceMode {
 		// Turn on maintenance mode for metasrv.
 		if err := common.SetMaintenanceMode(common.GetMetaHTTPServiceURL(cluster), true); err != nil {
 			return false, err

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -734,6 +734,7 @@ _Appears in:_
 | `replicas` _integer_ | Replicas is the number of replicas of the meta. |  |  |
 | `readyReplicas` _integer_ | ReadyReplicas is the number of ready replicas of the meta. |  |  |
 | `etcdEndpoints` _string array_ | EtcdEndpoints is the endpoints of the etcd cluster. |  |  |
+| `maintenanceMode` _boolean_ | MaintenanceMode is the maintenance mode of the meta. |  |  |
 
 
 #### MonitoringSpec

--- a/hack/deploy-test-operator.yaml
+++ b/hack/deploy-test-operator.yaml
@@ -1,0 +1,305 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: greptimedb-operator-test
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: greptimedb-operator
+  namespace: greptimedb-operator-test
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: greptimedb-operator-leader-election-role
+  namespace: greptimedb-operator-test
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: greptimedb-operator-role
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - greptime.io
+  resources:
+  - greptimedbclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - greptime.io
+  resources:
+  - greptimedbclusters/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - greptime.io
+  resources:
+  - greptimedbclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - greptime.io
+  resources:
+  - greptimedbstandalones
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - greptime.io
+  resources:
+  - greptimedbstandalones/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - greptime.io
+  resources:
+  - greptimedbstandalones/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - podmonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: greptimedb-operator-leader-election-rolebinding
+  namespace: greptimedb-operator-test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: greptimedb-operator-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: greptimedb-operator
+  namespace: greptimedb-operator-test
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: greptimedb-operator-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: greptimedb-operator-role
+subjects:
+- kind: ServiceAccount
+  name: greptimedb-operator
+  namespace: greptimedb-operator-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: greptimedb-operator
+  namespace: greptimedb-operator-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --enable-leader-election
+        command:
+        - greptimedb-operator
+        image: localhost:5001/greptime/greptimedb-operator:latest
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9494
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 9494
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+      serviceAccountName: greptimedb-operator
+      terminationGracePeriodSeconds: 10

--- a/manifests/bundle.yaml
+++ b/manifests/bundle.yaml
@@ -22071,6 +22071,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  maintenanceMode:
+                    type: boolean
                   readyReplicas:
                     format: int32
                     type: integer
@@ -22078,6 +22080,7 @@ spec:
                     format: int32
                     type: integer
                 required:
+                - maintenanceMode
                 - readyReplicas
                 - replicas
                 type: object

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -22064,6 +22064,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  maintenanceMode:
+                    type: boolean
                   readyReplicas:
                     format: int32
                     type: integer
@@ -22071,6 +22073,7 @@ spec:
                     format: int32
                     type: integer
                 required:
+                - maintenanceMode
                 - readyReplicas
                 - replicas
                 type: object

--- a/tests/e2e/testdata/resources/cluster/frontend-groups-ingress/cluster.yaml
+++ b/tests/e2e/testdata/resources/cluster/frontend-groups-ingress/cluster.yaml
@@ -5,10 +5,10 @@ metadata:
   namespace: default
 spec:
   initializer:
-    image: greptime-registry.cn-hangzhou.cr.aliyuncs.com/greptime/greptimedb-initializer:latest
+    image: localhost:5001/greptime/greptimedb-initializer:latest
   base:
     main:
-      image: greptime-registry.cn-hangzhou.cr.aliyuncs.com/greptime/greptimedb:latest
+      image: localhost:5001/greptime/greptimedb:latest
   frontendGroups:
     - name: read
       replicas: 1

--- a/tests/e2e/testdata/resources/cluster/frontend-ingress/cluster.yaml
+++ b/tests/e2e/testdata/resources/cluster/frontend-ingress/cluster.yaml
@@ -5,10 +5,10 @@ metadata:
   namespace: default
 spec:
   initializer:
-    image: greptime-registry.cn-hangzhou.cr.aliyuncs.com/greptime/greptimedb-initializer:latest
+    image: localhost:5001/greptime/greptimedb-initializer:latest
   base:
     main:
-      image: greptime-registry.cn-hangzhou.cr.aliyuncs.com/greptime/greptimedb:latest
+      image: localhost:5001/greptime/greptimedb:latest
   frontend:
     replicas: 1
   meta:


### PR DESCRIPTION
## What's changed

For resolve https://github.com/GreptimeTeam/greptimedb-operator/issues/279.

1. Add `MaintenanceMode` in `MetaStatus`;
2. Enable maintaince mode when cluster is starting;
3. (chore) Add `hack/deploy-test-operator.yaml` for easy testing;