### PR TITLE
refactor: use the new etcd endpoints structure in the example and tests directory

### DIFF
--- a/examples/cluster/add-custom-config/cluster.yaml
+++ b/examples/cluster/add-custom-config/cluster.yaml
@@ -10,8 +10,10 @@ spec:
     replicas: 1
   meta:
     replicas: 1
-    etcdEndpoints:
-      - "etcd.etcd-cluster.svc.cluster.local:2379"
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 1
     config: |

--- a/examples/cluster/aws-nlb/cluster.yaml
+++ b/examples/cluster/aws-nlb/cluster.yaml
@@ -16,7 +16,9 @@ spec:
         external-dns.alpha.kubernetes.io/hostname: "test.greptime.io"
   meta:
     replicas: 1
-    etcdEndpoints:
-      - "etcd.etcd-cluster.svc.cluster.local:2379"
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 1

--- a/examples/cluster/azblob/cluster.yaml
+++ b/examples/cluster/azblob/cluster.yaml
@@ -10,8 +10,10 @@ spec:
     replicas: 1
   meta:
     replicas: 1
-    etcdEndpoints:
-      - "etcd.etcd-cluster.svc.cluster.local:2379"
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 1
   objectStorage:

--- a/examples/cluster/basic/cluster.yaml
+++ b/examples/cluster/basic/cluster.yaml
@@ -10,7 +10,9 @@ spec:
     replicas: 1
   meta:
     replicas: 1
-    etcdEndpoints:
-      - "etcd.etcd-cluster.svc.cluster.local:2379"
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 1

--- a/examples/cluster/configure-frontend-groups/cluster.yaml
+++ b/examples/cluster/configure-frontend-groups/cluster.yaml
@@ -15,7 +15,9 @@ spec:
     replicas: 1
   meta:
     replicas: 1
-    etcdEndpoints:
-      - "etcd.etcd-cluster.svc.cluster.local:2379"
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 1

--- a/examples/cluster/configure-logging/cluster.yaml
+++ b/examples/cluster/configure-logging/cluster.yaml
@@ -15,8 +15,10 @@ spec:
     replicas: 1
   meta:
     replicas: 1
-    etcdEndpoints:
-      - "etcd.etcd-cluster.svc.cluster.local:2379"
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 1
     logging:

--- a/examples/cluster/dedicated-wal/cluster.yaml
+++ b/examples/cluster/dedicated-wal/cluster.yaml
@@ -10,8 +10,10 @@ spec:
     replicas: 1
   meta:
     replicas: 1
-    etcdEndpoints:
-      - "etcd.etcd-cluster:2379"
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 1
   wal:

--- a/examples/cluster/enable-monitoring/cluster.yaml
+++ b/examples/cluster/enable-monitoring/cluster.yaml
@@ -10,8 +10,10 @@ spec:
     replicas: 1
   meta:
     replicas: 1
-    etcdEndpoints:
-      - "etcd.etcd-cluster.svc.cluster.local:2379"
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 1
   monitoring:

--- a/examples/cluster/flownode/cluster.yaml
+++ b/examples/cluster/flownode/cluster.yaml
@@ -10,8 +10,10 @@ spec:
     replicas: 1
   meta:
     replicas: 1
-    etcdEndpoints:
-      - "etcd.etcd-cluster.svc.cluster.local:2379"
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 1
   flownode:

--- a/examples/cluster/frontend-groups-ingress/cluster.yaml
+++ b/examples/cluster/frontend-groups-ingress/cluster.yaml
@@ -15,8 +15,10 @@ spec:
       replicas: 1
   meta:
     replicas: 1
-    etcdEndpoints:
-      - "etcd.etcd-cluster.svc.cluster.local:2379"
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 1
   ingress:

--- a/examples/cluster/frontend-ingress/cluster.yaml
+++ b/examples/cluster/frontend-ingress/cluster.yaml
@@ -12,8 +12,10 @@ spec:
     replicas: 1
   meta:
     replicas: 1
-    etcdEndpoints:
-      - "etcd.etcd-cluster.svc.cluster.local:2379"
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 1
   ingress:

--- a/examples/cluster/gcs/cluster.yaml
+++ b/examples/cluster/gcs/cluster.yaml
@@ -10,8 +10,10 @@ spec:
     replicas: 1
   meta:
     replicas: 1
-    etcdEndpoints:
-      - "etcd.etcd-cluster.svc.cluster.local:2379"
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 1
   objectStorage:

--- a/examples/cluster/kafka-remote-wal/cluster.yaml
+++ b/examples/cluster/kafka-remote-wal/cluster.yaml
@@ -10,8 +10,10 @@ spec:
     replicas: 1
   meta:
     replicas: 1
-    etcdEndpoints:
-      - "etcd.etcd-cluster.svc.cluster.local:2379"
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 1
   wal:

--- a/examples/cluster/oss/cluster.yaml
+++ b/examples/cluster/oss/cluster.yaml
@@ -10,8 +10,10 @@ spec:
     replicas: 1
   meta:
     replicas: 1
-    etcdEndpoints:
-      - "etcd.etcd-cluster.svc.cluster.local:2379"
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 1
   objectStorage:

--- a/examples/cluster/prometheus-monitor/cluster.yaml
+++ b/examples/cluster/prometheus-monitor/cluster.yaml
@@ -10,8 +10,10 @@ spec:
     replicas: 1
   meta:
     replicas: 1
-    etcdEndpoints:
-      - "etcd.etcd-cluster.svc.cluster.local:2379"
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 1
   prometheusMonitor: # Make sure you have already installed prometheus-operator and created a Prometheus instance with the label `release=prometheus`.

--- a/examples/cluster/s3/cluster.yaml
+++ b/examples/cluster/s3/cluster.yaml
@@ -10,8 +10,10 @@ spec:
     replicas: 1
   meta:
     replicas: 1
-    etcdEndpoints:
-      - "etcd.etcd-cluster.svc.cluster.local:2379"
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 1
   objectStorage:

--- a/examples/cluster/tls-service/cluster.yaml
+++ b/examples/cluster/tls-service/cluster.yaml
@@ -12,7 +12,9 @@ spec:
       secretName: frontend-tls
   meta:
     replicas: 1
-    etcdEndpoints:
-      - "etcd.etcd-cluster.svc.cluster.local:2379"
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 1

--- a/tests/e2e/testdata/resources/cluster/basic/cluster.yaml
+++ b/tests/e2e/testdata/resources/cluster/basic/cluster.yaml
@@ -13,7 +13,9 @@ spec:
     replicas: 1
   meta:
     replicas: 1
-    etcdEndpoints:
-      - etcd.etcd-cluster:2379
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 3

--- a/tests/e2e/testdata/resources/cluster/configure-frontend-groups/cluster.yaml
+++ b/tests/e2e/testdata/resources/cluster/configure-frontend-groups/cluster.yaml
@@ -16,7 +16,9 @@ spec:
     replicas: 2
   meta:
     replicas: 1
-    etcdEndpoints:
-      - etcd.etcd-cluster:2379
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 3

--- a/tests/e2e/testdata/resources/cluster/dedicated-wal/cluster.yaml
+++ b/tests/e2e/testdata/resources/cluster/dedicated-wal/cluster.yaml
@@ -13,8 +13,10 @@ spec:
     replicas: 1
   meta:
     replicas: 1
-    etcdEndpoints:
-      - "etcd.etcd-cluster:2379"
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 1
   wal:

--- a/tests/e2e/testdata/resources/cluster/enable-flow/cluster.yaml
+++ b/tests/e2e/testdata/resources/cluster/enable-flow/cluster.yaml
@@ -13,8 +13,10 @@ spec:
     replicas: 1
   meta:
     replicas: 1
-    etcdEndpoints:
-      - etcd.etcd-cluster:2379
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 3
   flownode:

--- a/tests/e2e/testdata/resources/cluster/enable-monitoring/cluster.yaml
+++ b/tests/e2e/testdata/resources/cluster/enable-monitoring/cluster.yaml
@@ -13,8 +13,10 @@ spec:
     replicas: 1
   meta:
     replicas: 1
-    etcdEndpoints:
-      - "etcd.etcd-cluster.svc.cluster.local:2379"
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 1
   monitoring:

--- a/tests/e2e/testdata/resources/cluster/enable-remote-wal/cluster.yaml
+++ b/tests/e2e/testdata/resources/cluster/enable-remote-wal/cluster.yaml
@@ -13,8 +13,10 @@ spec:
     replicas: 1
   meta:
     replicas: 1
-    etcdEndpoints:
-      - etcd.etcd-cluster:2379
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 3
   wal:

--- a/tests/e2e/testdata/resources/cluster/frontend-groups-ingress/cluster.yaml
+++ b/tests/e2e/testdata/resources/cluster/frontend-groups-ingress/cluster.yaml
@@ -16,8 +16,10 @@ spec:
       replicas: 1
   meta:
     replicas: 1
-    etcdEndpoints:
-      - "etcd.etcd-cluster.svc.cluster.local:2379"
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 1
   ingress:

--- a/tests/e2e/testdata/resources/cluster/frontend-ingress/cluster.yaml
+++ b/tests/e2e/testdata/resources/cluster/frontend-ingress/cluster.yaml
@@ -13,8 +13,10 @@ spec:
     replicas: 1
   meta:
     replicas: 1
-    etcdEndpoints:
-      - "etcd.etcd-cluster.svc.cluster.local:2379"
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 1
   ingress:

--- a/tests/e2e/testdata/resources/cluster/scale/cluster.yaml
+++ b/tests/e2e/testdata/resources/cluster/scale/cluster.yaml
@@ -13,8 +13,10 @@ spec:
     replicas: 1
   meta:
     replicas: 1
-    etcdEndpoints:
-      - etcd.etcd-cluster:2379
+    backendStorage:
+      etcd:
+        endpoints:
+          - "etcd.etcd-cluster.svc.cluster.local:2379"
   datanode:
     replicas: 1
     storage:


### PR DESCRIPTION
related PR: https://github.com/GreptimeTeam/greptimedb-operator/pull/274

old structure:
```
meta:
  replicas: 1
  etcdEndpoints:
    - "etcd.etcd-cluster.svc.cluster.local:2379"
```

new structure:
```
meta:
  replicas: 1
  backendStorage:
    etcd:
      endpoints:
        - "etcd.etcd-cluster.svc.cluster.local:2379"
```