### PR TITLE
chore: disable leader election by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ initializer: ## Build greptimedb-initializer binary.
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	GO111MODULE=on CGO_ENABLED=0 go run -ldflags '${LDFLAGS}' ./cmd/operator/main.go --enable-leader-election=false
+	GO111MODULE=on CGO_ENABLED=0 go run -ldflags '${LDFLAGS}' ./cmd/operator/main.go
 
 .PHONY: docker-build-operator
 docker-build-operator: ## Build docker image with the greptimedb-operator.

--- a/cmd/operator/app/options/options.go
+++ b/cmd/operator/app/options/options.go
@@ -46,7 +46,7 @@ func NewDefaultOptions() *Options {
 		MetricsAddr:             defaultMetricsAddr,
 		HealthProbeAddr:         defaultHealthProbeAddr,
 		APIServerPort:           defaultAPIServerPort,
-		EnableLeaderElection:    true,
+		EnableLeaderElection:    false,
 		EnableAPIServer:         false,
 		EnablePodMetrics:        false,
 		EnableAdmissionWebhook:  false,


### PR DESCRIPTION
Leader election requires the k8s resource lease as lock, cannot used in the local test environment (make run). In the container environment, can use the start args `--enable-leader-election` to enable leader election.