### PR TITLE
fix: incorrect description for meta postgresql backend storage

### DIFF
--- a/apis/v1alpha1/greptimedbcluster_types.go
+++ b/apis/v1alpha1/greptimedbcluster_types.go
@@ -235,11 +235,11 @@ type PostgreSQLStorage struct {
 	// +required
 	CredentialsSecretName string `json:"credentialsSecretName"`
 
-	// Database is the name of the MySQL database.
+	// Database is the name of the PostgreSQL database.
 	// +optional
 	Database string `json:"database,omitempty"`
 
-	// Table is the name of the MySQL table.
+	// Table is the name of the PostgreSQL table.
 	// +optional
 	Table string `json:"table,omitempty"`
 }

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -910,8 +910,8 @@ _Appears in:_
 | `host` _string_ | Host is the host of the PostgreSQL database. |  |  |
 | `port` _integer_ | Port is the port of the PostgreSQL database. |  | Maximum: 65535 <br />Minimum: 0 <br /> |
 | `credentialsSecretName` _string_ | CredentialsSecretName is the name of the secret that contains the credentials for the MySQL database.<br />The secret must be in the same namespace with the greptime resource.<br />The secret must contain keys named `username` and `password`. |  |  |
-| `database` _string_ | Database is the name of the MySQL database. |  |  |
-| `table` _string_ | Table is the name of the MySQL table. |  |  |
+| `database` _string_ | Database is the name of the PostgreSQL database. |  |  |
+| `table` _string_ | Table is the name of the PostgreSQL table. |  |  |
 
 
 #### PrometheusMonitorSpec


### PR DESCRIPTION
The fields is in the PostgreSQLStorage struct.