### PR TITLE
fix(crds): image filed is not required

### DIFF
--- a/apis/v1alpha1/common.go
+++ b/apis/v1alpha1/common.go
@@ -199,7 +199,7 @@ type SlimPodSpec struct {
 // Most of the fields of MainContainerSpec are from 'corev1.Container'.
 type MainContainerSpec struct {
 	// The main container image name of the component.
-	// +required
+	// +optional
 	Image string `json:"image,omitempty"`
 
 	// The resource requirements of the main container.

--- a/config/crd/resources/greptime.io_greptimedbclusters.yaml
+++ b/config/crd/resources/greptime.io_greptimedbclusters.yaml
@@ -2450,8 +2450,6 @@ spec:
                         type: array
                       workingDir:
                         type: string
-                    required:
-                    - image
                     type: object
                   nodeSelector:
                     additionalProperties:
@@ -5829,8 +5827,6 @@ spec:
                             type: array
                           workingDir:
                             type: string
-                        required:
-                        - image
                         type: object
                       nodeSelector:
                         additionalProperties:
@@ -9210,8 +9206,6 @@ spec:
                               type: array
                             workingDir:
                               type: string
-                          required:
-                          - image
                           type: object
                         nodeSelector:
                           additionalProperties:
@@ -12559,8 +12553,6 @@ spec:
                             type: array
                           workingDir:
                             type: string
-                        required:
-                        - image
                         type: object
                       nodeSelector:
                         additionalProperties:
@@ -15952,8 +15944,6 @@ spec:
                             type: array
                           workingDir:
                             type: string
-                        required:
-                        - image
                         type: object
                       nodeSelector:
                         additionalProperties:
@@ -19353,8 +19343,6 @@ spec:
                               type: array
                             workingDir:
                               type: string
-                          required:
-                          - image
                           type: object
                         nodeSelector:
                           additionalProperties:
@@ -22858,8 +22846,6 @@ spec:
                             type: array
                           workingDir:
                             type: string
-                        required:
-                        - image
                         type: object
                       nodeSelector:
                         additionalProperties:
@@ -26166,8 +26152,6 @@ spec:
                                 type: array
                               workingDir:
                                 type: string
-                            required:
-                            - image
                             type: object
                           nodeSelector:
                             additionalProperties:

--- a/config/crd/resources/greptime.io_greptimedbstandalones.yaml
+++ b/config/crd/resources/greptime.io_greptimedbstandalones.yaml
@@ -2438,8 +2438,6 @@ spec:
                         type: array
                       workingDir:
                         type: string
-                    required:
-                    - image
                     type: object
                   nodeSelector:
                     additionalProperties:

--- a/manifests/bundle.yaml
+++ b/manifests/bundle.yaml
@@ -2456,8 +2456,6 @@ spec:
                         type: array
                       workingDir:
                         type: string
-                    required:
-                    - image
                     type: object
                   nodeSelector:
                     additionalProperties:
@@ -5835,8 +5833,6 @@ spec:
                             type: array
                           workingDir:
                             type: string
-                        required:
-                        - image
                         type: object
                       nodeSelector:
                         additionalProperties:
@@ -9216,8 +9212,6 @@ spec:
                               type: array
                             workingDir:
                               type: string
-                          required:
-                          - image
                           type: object
                         nodeSelector:
                           additionalProperties:
@@ -12565,8 +12559,6 @@ spec:
                             type: array
                           workingDir:
                             type: string
-                        required:
-                        - image
                         type: object
                       nodeSelector:
                         additionalProperties:
@@ -15958,8 +15950,6 @@ spec:
                             type: array
                           workingDir:
                             type: string
-                        required:
-                        - image
                         type: object
                       nodeSelector:
                         additionalProperties:
@@ -19359,8 +19349,6 @@ spec:
                               type: array
                             workingDir:
                               type: string
-                          required:
-                          - image
                           type: object
                         nodeSelector:
                           additionalProperties:
@@ -22864,8 +22852,6 @@ spec:
                             type: array
                           workingDir:
                             type: string
-                        required:
-                        - image
                         type: object
                       nodeSelector:
                         additionalProperties:
@@ -26172,8 +26158,6 @@ spec:
                                 type: array
                               workingDir:
                                 type: string
-                            required:
-                            - image
                             type: object
                           nodeSelector:
                             additionalProperties:
@@ -30099,8 +30083,6 @@ spec:
                         type: array
                       workingDir:
                         type: string
-                    required:
-                    - image
                     type: object
                   nodeSelector:
                     additionalProperties:

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -2449,8 +2449,6 @@ spec:
                         type: array
                       workingDir:
                         type: string
-                    required:
-                    - image
                     type: object
                   nodeSelector:
                     additionalProperties:
@@ -5828,8 +5826,6 @@ spec:
                             type: array
                           workingDir:
                             type: string
-                        required:
-                        - image
                         type: object
                       nodeSelector:
                         additionalProperties:
@@ -9209,8 +9205,6 @@ spec:
                               type: array
                             workingDir:
                               type: string
-                          required:
-                          - image
                           type: object
                         nodeSelector:
                           additionalProperties:
@@ -12558,8 +12552,6 @@ spec:
                             type: array
                           workingDir:
                             type: string
-                        required:
-                        - image
                         type: object
                       nodeSelector:
                         additionalProperties:
@@ -15951,8 +15943,6 @@ spec:
                             type: array
                           workingDir:
                             type: string
-                        required:
-                        - image
                         type: object
                       nodeSelector:
                         additionalProperties:
@@ -19352,8 +19342,6 @@ spec:
                               type: array
                             workingDir:
                               type: string
-                          required:
-                          - image
                           type: object
                         nodeSelector:
                           additionalProperties:
@@ -22857,8 +22845,6 @@ spec:
                             type: array
                           workingDir:
                             type: string
-                        required:
-                        - image
                         type: object
                       nodeSelector:
                         additionalProperties:
@@ -26165,8 +26151,6 @@ spec:
                                 type: array
                               workingDir:
                                 type: string
-                            required:
-                            - image
                             type: object
                           nodeSelector:
                             additionalProperties:
@@ -30092,8 +30076,6 @@ spec:
                         type: array
                       workingDir:
                         type: string
-                    required:
-                    - image
                     type: object
                   nodeSelector:
                     additionalProperties:


### PR DESCRIPTION
Only need to the `base.main.image` field. The image field of each component is not required by default.

Fixed to:
```
kubectl apply -f cluster.yaml


The GreptimeDBCluster "mycluster" is invalid:
* spec.flownode.template.main.image: Required value
* spec.frontend.template.main.image: Required value
* spec.datanode.template.main.image: Required value
* spec.meta.template.main.image: Required value

```

Failed Configuration:
```
apiVersion: greptime.io/v1alpha1
kind: GreptimeDBCluster
metadata:
  name: mycluster
  namespace: default
spec:
  base:
    main:
      image: 'docker.io/greptime/greptimedb:v0.14.4'
      resources:
        limits: {}
        requests: {}
    terminationGracePeriodSeconds: 30
  frontend:
    replicas: 1
    template:
      main:
        resources:
          requests:
            {}
          limits:
            {}
    slowQuery:
      enabled: true
      recordType: system_table
      threshold: 30s
      sampleRatio: "1.0"
      ttl: 30d
  meta:
    replicas: 1
    backendStorage:
      etcd:
        endpoints:
          - etcd.etcd-cluster.svc.cluster.local:2379
    template:
      main:
        resources:
          requests:
            {}
          limits:
            {}
  datanode:
    replicas: 1
    template:
      main:
        resources:
          requests:
            {}
          limits:
            {}
    storage:
      dataHome: /data/greptimedb
      fs:
        storageClassName:
        storageSize: 20Gi
        storageRetainPolicy: Retain
        mountPath: /data/greptimedb
  flownode:
    replicas: 1
    template:
      main:
        resources:
          requests:
            {}
          limits:
            {}
  httpPort: 4000
  rpcPort: 4001
  mysqlPort: 4002
  postgreSQLPort: 4003
  initializer:
    image: 'docker.io/greptime/greptimedb-initializer:v0.4.0'
  objectStorage:
    s3:
      bucket: bucket
      region: us-east-1
      root: mycluster-test
      secretName: storage-credentials
    cache:
      cacheCapacity: 20GiB
      fs:
        mountPath: /cache
        name: cache
        storageSize: 20Gi
  logging:
    level: info
    format: text
    logsDir: /data/greptimedb/logs
```


The following configuration successful running:
```
apiVersion: greptime.io/v1alpha1
kind: GreptimeDBCluster
metadata:
  name: mycluster
  namespace: default
  labels:
    helm.sh/chart: greptimedb-cluster-0.5.6
    app.kubernetes.io/name: greptimedb-cluster
    app.kubernetes.io/instance: mycluster
    app.kubernetes.io/version: "0.14.4"
    app.kubernetes.io/component: cluster
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: greptimedb-cluster
spec:
  base:
    main:
      image: 'docker.io/greptime/greptimedb:v0.14.4'
      resources:
        limits: {}
        requests: {}
    terminationGracePeriodSeconds: 30
  frontend:
    replicas: 1
    template:
      main:
        image: docker.io/greptime/greptimedb:v0.14.4
        resources:
          requests:
            {}
          limits:
            {}
    slowQuery:
      enabled: true
      recordType: system_table
      threshold: 30s
      sampleRatio: "1.0"
      ttl: 30d
  meta:
    replicas: 1
    backendStorage:
      etcd:
        endpoints:
          - etcd.etcd-cluster.svc.cluster.local:2379
    template:
      main:
        image: docker.io/greptime/greptimedb:v0.14.4
        resources:
          requests:
            {}
          limits:
            {}
  datanode:
    replicas: 1
    template:
      main:
        image: docker.io/greptime/greptimedb:v0.14.4   <<======= add image field to each component =============>>
        resources:
          requests:
            {}
          limits:
            {}
    storage:
      dataHome: /data/greptimedb
      fs:
        storageClassName:
        storageSize: 20Gi
        storageRetainPolicy: Retain
        mountPath: /data/greptimedb
  flownode:
    replicas: 1
    template:
      main:
        image: docker.io/greptime/greptimedb:v0.14.4  <<====================>>
        resources:
          requests:
            {}
          limits:
            {}
  httpPort: 4000
  rpcPort: 4001
  mysqlPort: 4002
  postgreSQLPort: 4003
  initializer:
    image: 'docker.io/greptime/greptimedb-initializer:v0.4.0'
  objectStorage:
    s3:
      bucket: bucket
      region: us-east-1
      root: mycluster-test
      secretName: storage-credentials
    cache:
      cacheCapacity: 20GiB
      fs:
        mountPath: /cache
        name: cache
        storageSize: 20Gi
  logging:
    level: info
    format: text
    logsDir: /data/greptimedb/logs
```