### PR TITLE
chore: increase default limit of the vector resource

### DIFF
--- a/apis/v1alpha1/constants.go
+++ b/apis/v1alpha1/constants.go
@@ -75,6 +75,12 @@ const (
 
 	// DefaultVectorMemoryRequest is the default memory request for the vector.
 	DefaultVectorMemoryRequest = "64Mi"
+
+	// DefaultVectorCPULimit is the default CPU limit for the vector.
+	DefaultVectorCPULimit = "250m"
+
+	// DefaultVectorMemoryLimit is the default memory limit for the vector.
+	DefaultVectorMemoryLimit = "256Mi"
 )
 
 // The following constants are the constant configuration for the GreptimeDBCluster and GreptimeDBStandalone.

--- a/apis/v1alpha1/defaulting.go
+++ b/apis/v1alpha1/defaulting.go
@@ -176,8 +176,8 @@ func (in *GreptimeDBCluster) defaultSpec() *GreptimeDBClusterSpec {
 						corev1.ResourceMemory: resource.MustParse(DefaultVectorMemoryRequest),
 					},
 					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse(DefaultVectorCPURequest),
-						corev1.ResourceMemory: resource.MustParse(DefaultVectorMemoryRequest),
+						corev1.ResourceCPU:    resource.MustParse(DefaultVectorCPULimit),
+						corev1.ResourceMemory: resource.MustParse(DefaultVectorMemoryLimit),
 					},
 				},
 			},


### PR DESCRIPTION
request:
- cpu: 50m
- memory: 64Mi

limit:
- cpu: 200m
- memory: 256Mi