### PR TITLE
chore: add some dev manifests

### DIFF
--- a/hack/kafka/kafka-dev.yaml
+++ b/hack/kafka/kafka-dev.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+  namespace: default
+  labels:
+    app: kafka
+spec:
+  ports:
+    - name: client
+      port: 9092
+      targetPort: 9092
+  selector:
+    app: kafka
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-hl
+  namespace: default
+  labels:
+    app: kafka
+spec:
+  clusterIP: None
+  selector:
+    app: kafka
+  ports:
+    - name: controller
+      port: 9093
+      targetPort: 9093
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kafka
+  namespace: default
+spec:
+  serviceName: kafka-hl
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      containers:
+        - name: kafka
+          image: bitnami/kafka:3.7
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: client
+              containerPort: 9092
+            - name: controller
+              containerPort: 9093
+          env:
+            - name: KAFKA_ENABLE_KRAFT
+              value: "yes"
+            - name: KAFKA_CFG_PROCESS_ROLES
+              value: "broker,controller"
+            - name: KAFKA_CFG_NODE_ID
+              value: "0"
+            - name: KAFKA_CFG_CONTROLLER_QUORUM_VOTERS
+              value: "0@kafka-0.kafka-hl.default.svc.cluster.local:9093"
+            - name: KAFKA_CFG_LISTENERS
+              value: "PLAINTEXT://:9092,CONTROLLER://:9093"
+            - name: KAFKA_CFG_ADVERTISED_LISTENERS
+              value: "PLAINTEXT://kafka:9092"
+            - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
+              value: "PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT"
+            - name: KAFKA_CFG_CONTROLLER_LISTENER_NAMES
+              value: "CONTROLLER"
+            - name: KAFKA_CFG_INTER_BROKER_LISTENER_NAME
+              value: "PLAINTEXT"
+            - name: KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE
+              value: "true"
+            - name: KAFKA_HEAP_OPTS
+              value: "-Xms512m -Xmx512m"
+          volumeMounts:
+            - name: data
+              mountPath: /bitnami/kafka
+          readinessProbe:
+            tcpSocket:
+              port: 9092
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 12
+          livenessProbe:
+            tcpSocket:
+              port: 9092
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+      volumes:
+        - name: data
+          emptyDir: {}

--- a/hack/minio/minio-dev.yaml
+++ b/hack/minio/minio-dev.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-dev
+spec:
+  ports:
+    - name: api
+      port: 9000
+      targetPort: 9000
+    - name: console
+      port: 9001
+      targetPort: 9001
+  selector:
+    app: minio
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: minio
+  name: minio
+spec:
+  containers:
+  - name: minio
+    image: quay.io/minio/minio:RELEASE.2025-02-18T16-25-55Z
+    command:
+    - /bin/bash
+    - -c
+    args: 
+    - minio server /data --console-address :9001
+    ports:
+    - containerPort: 9000
+      name: api
+    - containerPort: 9001
+      name: console
+    volumeMounts:
+    - mountPath: /data
+      name: localvolume
+  volumes:
+  - name: localvolume
+    emptyDir: {} # This is a temporary volume that will be deleted when the pod is deleted.

--- a/hack/minio/setup-minio.sh
+++ b/hack/minio/setup-minio.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+
+BUCKET_NAME=testbucket
+USER_NAME=testuser
+USER_PASSWORD=testpassword
+ACCESS_KEY=testaccesskey
+SECRET_KEY=testsecretkey
+# You may need to execute the port-forwarding command to expose the minio service to the local machine.
+# kubectl port-forward svc/minio-dev 9000:9000 9001:9001
+MINIO_ENDPOINT=http://localhost:9000
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=minioadmin
+
+# Configure mc client to connect to MinIO.
+echo "Configuring mc client..."
+mc alias set local $MINIO_ENDPOINT $MINIO_ROOT_USER $MINIO_ROOT_PASSWORD
+
+# If the bucket already exists, exit 0.
+if mc ls local/$BUCKET_NAME; then
+  echo "Bucket already exists, exiting..."
+  exit 0
+fi
+
+# Create test bucket.
+echo "Creating test bucket..."
+mc mb local/$BUCKET_NAME
+
+# Set bucket policy to public read (optional).
+echo "Setting bucket policy..."
+mc anonymous set public local/$BUCKET_NAME
+
+# Create a test user and access key.
+echo "Creating test user..."
+mc admin user add local $USER_NAME $USER_PASSWORD
+
+# Create access key.
+echo "Creating access key..."
+mc admin user svcacct add local $USER_NAME --access-key $ACCESS_KEY --secret-key $SECRET_KEY
+
+# Attach readwrite policy to the user.
+mc admin policy attach local readwrite --user $USER_NAME


### PR DESCRIPTION
## What's changed

- `kafka-dev.yaml`: Create a single kafka by using emptydir;
- `minio-dev.yaml`: Create a single minio by using emptydir. Also, use `setup-minio.sh` to create the test bucket;