### PR TITLE
refactor: add some helper functions to make `defaulting.go` clean

### DIFF
--- a/apis/v1alpha1/common.go
+++ b/apis/v1alpha1/common.go
@@ -996,7 +996,7 @@ type SlowQuery struct {
 	// +kubebuilder:validation:Type=string
 	SampleRatio string `json:"sampleRatio,omitempty"`
 
-	// TTL is the TTL of the slow query log. Default to `30d`.
+	// TTL is the TTL of the slow query log. Default to `90d`.
 	// +optional
 	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h|d))+$"
 	TTL string `json:"ttl,omitempty"`

--- a/apis/v1alpha1/defaulting_test.go
+++ b/apis/v1alpha1/defaulting_test.go
@@ -127,11 +127,11 @@ func TestClusterMerge(t *testing.T) {
 				t.Fatalf("failed to set defaults: %v", err)
 			}
 
-			if err := input.MergeTemplate(); err != nil {
+			if err := input.MergeWithBaseTemplate(); err != nil {
 				t.Fatalf("failed to merge template: %v", err)
 			}
 
-			if err := input.MergeLogging(); err != nil {
+			if err := input.MergeWithGlobalLogging(); err != nil {
 				t.Fatalf("failed to merge logging: %v", err)
 			}
 

--- a/apis/v1alpha1/greptimedbcluster_types.go
+++ b/apis/v1alpha1/greptimedbcluster_types.go
@@ -866,6 +866,72 @@ func (in *GreptimeDBCluster) GetIngress() *IngressSpec {
 	return nil
 }
 
+func (in *GreptimeDBCluster) getAllLoggingSpecs() []*LoggingSpec {
+	var specs []*LoggingSpec
+
+	if logging := in.GetMeta().GetLogging(); logging != nil {
+		specs = append(specs, logging)
+	}
+
+	if logging := in.GetFlownode().GetLogging(); logging != nil {
+		specs = append(specs, logging)
+	}
+
+	if logging := in.GetDatanode().GetLogging(); logging != nil {
+		specs = append(specs, logging)
+	}
+	for _, datanode := range in.GetDatanodeGroups() {
+		if logging := datanode.GetLogging(); logging != nil {
+			specs = append(specs, logging)
+		}
+	}
+
+	if logging := in.GetFrontend().GetLogging(); logging != nil {
+		specs = append(specs, logging)
+	}
+	for _, frontend := range in.GetFrontendGroups() {
+		if logging := frontend.GetLogging(); logging != nil {
+			specs = append(specs, logging)
+		}
+	}
+
+	return specs
+}
+
+func (in *GreptimeDBCluster) getAllTracingSpecs() []*TracingSpec {
+	var specs []*TracingSpec
+
+	if tracing := in.GetMeta().GetTracing(); tracing != nil {
+		specs = append(specs, tracing)
+	}
+
+	if tracing := in.GetFlownode().GetTracing(); tracing != nil {
+		specs = append(specs, tracing)
+	}
+
+	if tracing := in.GetDatanode().GetTracing(); tracing != nil {
+		specs = append(specs, tracing)
+	}
+
+	for _, datanode := range in.GetDatanodeGroups() {
+		if tracing := datanode.GetTracing(); tracing != nil {
+			specs = append(specs, tracing)
+		}
+	}
+
+	if tracing := in.GetFrontend().GetTracing(); tracing != nil {
+		specs = append(specs, tracing)
+	}
+
+	for _, frontend := range in.GetFrontendGroups() {
+		if tracing := frontend.GetTracing(); tracing != nil {
+			specs = append(specs, tracing)
+		}
+	}
+
+	return specs
+}
+
 // GreptimeDBClusterStatus defines the observed state of GreptimeDBCluster
 type GreptimeDBClusterStatus struct {
 	// Frontend is the status of frontend node.

--- a/apis/v1alpha1/testdata/defaulting/greptimedbcluster/merge/test01/expect.yaml
+++ b/apis/v1alpha1/testdata/defaulting/greptimedbcluster/merge/test01/expect.yaml
@@ -59,7 +59,7 @@ spec:
       recordType: system_table
       sampleRatio: "1.0"
       threshold: 30s
-      ttl: 30d
+      ttl: 90d
     logging:
       format: text
       level: info

--- a/apis/v1alpha1/testdata/defaulting/greptimedbcluster/merge/test02/expect.yaml
+++ b/apis/v1alpha1/testdata/defaulting/greptimedbcluster/merge/test02/expect.yaml
@@ -155,7 +155,7 @@ spec:
       recordType: system_table
       sampleRatio: "1.0"
       threshold: 30s
-      ttl: 30d
+      ttl: 90d
     template:
       main:
         image: greptime/greptimedb:latest
@@ -207,7 +207,7 @@ spec:
       recordType: system_table
       sampleRatio: "1.0"
       threshold: 30s
-      ttl: 30d
+      ttl: 90d
     template:
       main:
         image: greptime/greptimedb:latest

--- a/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test00/expect.yaml
+++ b/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test00/expect.yaml
@@ -57,7 +57,7 @@ spec:
       recordType: system_table
       sampleRatio: "1.0"
       threshold: 30s
-      ttl: 30d
+      ttl: 90d
   meta:
     backendStorage:
       etcd:

--- a/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test01/expect.yaml
+++ b/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test01/expect.yaml
@@ -69,7 +69,7 @@ spec:
       recordType: system_table
       sampleRatio: "1.0"
       threshold: 30s
-      ttl: 30d
+      ttl: 90d
   meta:
     backendStorage:
       etcd:

--- a/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test02/expect.yaml
+++ b/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test02/expect.yaml
@@ -68,7 +68,7 @@ spec:
       recordType: system_table
       sampleRatio: "1.0"
       threshold: 30s
-      ttl: 30d
+      ttl: 90d
   meta:
     backendStorage:
       etcd:

--- a/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test03/expect.yaml
+++ b/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test03/expect.yaml
@@ -68,7 +68,7 @@ spec:
       recordType: system_table
       sampleRatio: "1.0"
       threshold: 30s
-      ttl: 30d
+      ttl: 90d
   meta:
     backendStorage:
       etcd:
@@ -154,7 +154,7 @@ spec:
         recordType: system_table
         sampleRatio: "1.0"
         threshold: 30s
-        ttl: 30d
+        ttl: 90d
     vector:
       image: timberio/vector:nightly-alpine
       resources:

--- a/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test04/expect.yaml
+++ b/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test04/expect.yaml
@@ -52,7 +52,7 @@ spec:
       recordType: system_table
       sampleRatio: "1.0"
       threshold: 30s
-      ttl: 30d
+      ttl: 90d
     logging: {}
     tracing: {}
     template: {}
@@ -75,7 +75,7 @@ spec:
       recordType: system_table
       sampleRatio: "1.0"
       threshold: 30s
-      ttl: 30d
+      ttl: 90d
     rollingUpdate:
       maxSurge: 50%
       maxUnavailable: 50%

--- a/apis/v1alpha1/testdata/defaulting/greptimedbstandalone/test00/expect.yaml
+++ b/apis/v1alpha1/testdata/defaulting/greptimedbstandalone/test00/expect.yaml
@@ -53,4 +53,4 @@ spec:
     recordType: system_table
     sampleRatio: "1.0"
     threshold: 30s
-    ttl: 30d
+    ttl: 90d

--- a/controllers/greptimedbcluster/controller.go
+++ b/controllers/greptimedbcluster/controller.go
@@ -180,15 +180,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
-	if err := cluster.MergeTemplate(); err != nil {
+	if err := cluster.MergeWithBaseTemplate(); err != nil {
 		return ctrl.Result{}, err
 	}
 
-	if err := cluster.MergeLogging(); err != nil {
+	if err := cluster.MergeWithGlobalLogging(); err != nil {
 		return ctrl.Result{}, err
 	}
 
-	if err := cluster.MergeTracing(); err != nil {
+	if err := cluster.MergeWithGlobalTracing(); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -1056,7 +1056,7 @@ _Appears in:_
 | `recordType` _[SlowQueryRecordType](#slowqueryrecordtype)_ | RecordType is the type of the slow query record. Default to `system_table`. |  |  |
 | `threshold` _string_ | Threshold is the threshold of the slow query. Default to `30s`. |  | Pattern: `^([0-9]+(\.[0-9]+)?(ns\|us\|µs\|ms\|s\|m\|h))+$` <br /> |
 | `sampleRatio` _string_ | SampleRatio is the sampling ratio of slow query log. The value should be in the range of (0, 1]. Default to `1.0`. |  | Pattern: `^(0?\.\d+\|1(\.0+)?)$` <br />Type: string <br /> |
-| `ttl` _string_ | TTL is the TTL of the slow query log. Default to `30d`. |  | Pattern: `^([0-9]+(\.[0-9]+)?(ns\|us\|µs\|ms\|s\|m\|h\|d))+$` <br /> |
+| `ttl` _string_ | TTL is the TTL of the slow query log. Default to `90d`. |  | Pattern: `^([0-9]+(\.[0-9]+)?(ns\|us\|µs\|ms\|s\|m\|h\|d))+$` <br /> |
 
 
 #### SlowQueryRecordType


### PR DESCRIPTION
## What's changed

1. Add `mergeDefaultGroups()`;
2. Add `mergeWithBaseTemplate()`;
3. Add `getAllLoggingSpecs()` and `getAllTracingSpecs()`;
4. Refine some naming:
   - `MergeTemplate()` -> `MergeWithBaseTemplate()`;
   - `MergeLogging()` -> `MergeWithGlobalLogging()`;
   - `MergeTracing()` -> `MergeWithGlobalTracing()`;
   
5. Modify TTL of slow query system table from `30d` to `90d`;
 