### PR TITLE
chore: remove default tracing configuration when enable monitoring

### DIFF
--- a/apis/v1alpha1/defaulting.go
+++ b/apis/v1alpha1/defaulting.go
@@ -15,7 +15,6 @@
 package v1alpha1
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 
@@ -182,17 +181,6 @@ func (in *GreptimeDBCluster) defaultSpec() *GreptimeDBClusterSpec {
 
 		// Set the default logging format to JSON if monitoring is enabled.
 		defaultSpec.Logging.Format = LogFormatJSON
-
-		// Set the default tracing configuration if monitoring is enabled.
-		defaultSpec.Tracing = &TracingSpec{
-			Enabled:     ptr.To(true),
-			SampleRatio: "1.0",
-			Endpoint: fmt.Sprintf("%s.%s:%d/v1/otlp",
-				in.Name+"-monitor-"+string(StandaloneRoleKind),
-				in.Namespace,
-				DefaultHTTPPort,
-			),
-		}
 	}
 
 	return defaultSpec

--- a/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test03/expect.yaml
+++ b/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test03/expect.yaml
@@ -32,10 +32,6 @@ spec:
   rpcPort: 4001
   mysqlPort: 4002
   postgreSQLPort: 4003
-  tracing:
-    enabled: true
-    endpoint: test03-monitor-standalone.default:4000/v1/otlp
-    sampleRatio: "1.0"
   objectStorage:
     s3:
       bucket: greptimedb


### PR DESCRIPTION
It affects performance after enabled. User can refer to this configuration to enable it: https://github.com/GreptimeTeam/greptimedb-operator/blob/main/examples/cluster/configure-tracing/cluster.yaml