### PR TITLE
refactor!: use pod ip to set up `--rpc-server-addr` in datanode and flownode

### DIFF
--- a/cmd/initializer/internal/config_generator.go
+++ b/cmd/initializer/internal/config_generator.go
@@ -35,12 +35,7 @@ type Options struct {
 	RoleKind       string
 
 	// For generating config of datanode or flownode.
-	RPCPort     int32
-	ServiceName string
-
-	// Note: It's Deprecated and will be removed soon. For generating config of datanode.
-	DatanodeRPCPort     int32
-	DatanodeServiceName string
+	RPCPort int32
 
 	// DatanodeGroupID is the id of the datanode group when use `DatanodeGroups` in GreptimeDBCluster.
 	DatanodeGroupID int32
@@ -117,22 +112,16 @@ func (c *ConfigGenerator) generateDatanodeConfig(initConfig []byte) ([]byte, err
 	if len(podIP) == 0 {
 		return nil, fmt.Errorf("empty pod ip")
 	}
-	datanodeCfg.RPCBindAddr = ptr.To(fmt.Sprintf("%s:%d", podIP, c.DatanodeRPCPort))
+	datanodeCfg.RPCBindAddr = ptr.To(fmt.Sprintf("%s:%d", podIP, c.RPCPort))
 
 	podName := os.Getenv(deployer.EnvPodName)
 	if len(podName) == 0 {
 		return nil, fmt.Errorf("empty pod name")
 	}
 
-	datanodeCfg.RPCServerAddr = ptr.To(fmt.Sprintf("%s.%s.%s:%d", podName,
-		c.DatanodeServiceName, c.Namespace, c.DatanodeRPCPort))
+	datanodeCfg.RPCServerAddr = ptr.To(fmt.Sprintf("%s:%d", podIP, c.RPCPort))
 
-	configData, err := dbconfig.Marshal(cfg, v1alpha1.ConfigMergeStrategyOperatorFirst)
-	if err != nil {
-		return nil, err
-	}
-
-	return configData, nil
+	return dbconfig.Marshal(cfg, v1alpha1.ConfigMergeStrategyOperatorFirst)
 }
 
 func (c *ConfigGenerator) generateFlownodeConfig(initConfig []byte) ([]byte, error) {
@@ -167,8 +156,7 @@ func (c *ConfigGenerator) generateFlownodeConfig(initConfig []byte) ([]byte, err
 		return nil, fmt.Errorf("empty pod name")
 	}
 
-	flownodeCfg.RPCServerAddr = ptr.To(fmt.Sprintf("%s.%s.%s:%d", podName,
-		c.ServiceName, c.Namespace, c.RPCPort))
+	flownodeCfg.RPCServerAddr = ptr.To(fmt.Sprintf("%s:%d", podIP, c.RPCPort))
 
 	configData, err := dbconfig.Marshal(cfg, v1alpha1.ConfigMergeStrategyOperatorFirst)
 	if err != nil {

--- a/cmd/initializer/internal/config_generator_test.go
+++ b/cmd/initializer/internal/config_generator_test.go
@@ -46,12 +46,11 @@ func TestDatanodeConfigGenerator(t *testing.T) {
 	defer file.Close()
 
 	opts := &Options{
-		ConfigPath:          file.Name(),
-		InitConfigPath:      "testdata/datanode-config.toml",
-		Namespace:           testClusterNamespace,
-		RoleKind:            string(v1alpha1.DatanodeRoleKind),
-		DatanodeRPCPort:     testRPCPort,
-		DatanodeServiceName: testClusterService,
+		ConfigPath:     file.Name(),
+		InitConfigPath: "testdata/datanode-config.toml",
+		Namespace:      testClusterNamespace,
+		RoleKind:       string(v1alpha1.DatanodeRoleKind),
+		RPCPort:        testRPCPort,
 	}
 
 	t.Setenv(deployer.EnvPodIP, testPodIP)
@@ -93,7 +92,7 @@ func TestDatanodeConfigGenerator(t *testing.T) {
 	if !ok {
 		t.Fatalf("grpc server_addr is not string")
 	}
-	wantRPCServerAddr := fmt.Sprintf("%s.%s.%s:%d", testDatanodePodName, testClusterService, testClusterNamespace, testRPCPort)
+	wantRPCServerAddr := fmt.Sprintf("%s:%d", testPodIP, testRPCPort)
 	if !reflect.DeepEqual(wantRPCServerAddr, rpcServerAddr) {
 		t.Fatalf("RPCServerAddr is not equal, want: '%s', got: '%s'", wantRPCServerAddr, rpcServerAddr)
 	}
@@ -112,7 +111,6 @@ func TestFlownodeConfigGenerator(t *testing.T) {
 		Namespace:      testClusterNamespace,
 		RoleKind:       string(v1alpha1.FlownodeRoleKind),
 		RPCPort:        testRPCPort,
-		ServiceName:    testClusterService,
 	}
 
 	t.Setenv(deployer.EnvPodIP, testPodIP)
@@ -154,7 +152,7 @@ func TestFlownodeConfigGenerator(t *testing.T) {
 	if !ok {
 		t.Fatalf("grpc server_addr is not string")
 	}
-	wantRPCServerAddr := fmt.Sprintf("%s.%s.%s:%d", testFlownodePodName, testClusterService, testClusterNamespace, testRPCPort)
+	wantRPCServerAddr := fmt.Sprintf("%s:%d", testPodIP, testRPCPort)
 	if !reflect.DeepEqual(wantRPCServerAddr, rpcServerAddr) {
 		t.Fatalf("RPCServerAddr is not equal, want: '%s', got: '%s'", wantRPCServerAddr, rpcServerAddr)
 	}
@@ -170,13 +168,12 @@ func TestDatanodeConfigGeneratorWithDatanodeGroupID(t *testing.T) {
 	defer tmpConfigFile.Close()
 
 	opts := &Options{
-		ConfigPath:          tmpConfigFile.Name(),
-		InitConfigPath:      "testdata/datanode-config.toml",
-		Namespace:           testClusterNamespace,
-		RoleKind:            string(v1alpha1.DatanodeRoleKind),
-		DatanodeRPCPort:     testRPCPort,
-		DatanodeServiceName: testClusterService,
-		DatanodeGroupID:     testDatanodeGroupID,
+		ConfigPath:      tmpConfigFile.Name(),
+		InitConfigPath:  "testdata/datanode-config.toml",
+		Namespace:       testClusterNamespace,
+		RoleKind:        string(v1alpha1.DatanodeRoleKind),
+		RPCPort:         testRPCPort,
+		DatanodeGroupID: testDatanodeGroupID,
 	}
 
 	t.Setenv(deployer.EnvPodIP, testPodIP)

--- a/cmd/initializer/main.go
+++ b/cmd/initializer/main.go
@@ -29,13 +29,9 @@ func main() {
 
 	pflag.StringVar(&opts.ConfigPath, "config-path", "/etc/greptimedb/config.toml", "the config path")
 	pflag.StringVar(&opts.InitConfigPath, "init-config-path", "/etc/greptimedb/init-config.toml", "the init config path")
-	pflag.StringVar(&opts.Namespace, "namespace", "", "the namespace of greptimedb cluster")
 	pflag.StringVar(&opts.RoleKind, "component-kind", "", "the component kind")
 
-	pflag.StringVar(&opts.ServiceName, "service-name", "", "the name of service")
 	pflag.Int32Var(&opts.RPCPort, "rpc-port", 4001, "the RPC port")
-	pflag.StringVar(&opts.DatanodeServiceName, "datanode-service-name", "", "the name of datanode service")
-	pflag.Int32Var(&opts.DatanodeRPCPort, "datanode-rpc-port", 4001, "the datanode RPC port")
 	pflag.Int32Var(&opts.DatanodeGroupID, "datanode-group-id", -1, "the id of the datanode group")
 	klog.InitFlags(nil)
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)

--- a/controllers/greptimedbcluster/deployers/datanode.go
+++ b/controllers/greptimedbcluster/deployers/datanode.go
@@ -655,9 +655,7 @@ func (b *datanodeBuilder) generateInitializer(spec *v1alpha1.DatanodeSpec, group
 		Args: []string{
 			"--config-path", path.Join(constant.GreptimeDBConfigDir, constant.GreptimeDBConfigFileName),
 			"--init-config-path", path.Join(constant.GreptimeDBInitConfigDir, constant.GreptimeDBConfigFileName),
-			"--datanode-rpc-port", fmt.Sprintf("%d", spec.RPCPort),
-			"--datanode-service-name", common.ResourceName(b.Cluster.Name, b.RoleKind, spec.GetName()),
-			"--namespace", b.Cluster.Namespace,
+			"--rpc-port", fmt.Sprintf("%d", spec.RPCPort),
 			"--component-kind", string(b.RoleKind),
 		},
 		VolumeMounts: []corev1.VolumeMount{

--- a/controllers/greptimedbcluster/deployers/flownode.go
+++ b/controllers/greptimedbcluster/deployers/flownode.go
@@ -297,8 +297,6 @@ func (b *flownodeBuilder) generateInitializer() *corev1.Container {
 			"--config-path", path.Join(constant.GreptimeDBConfigDir, constant.GreptimeDBConfigFileName),
 			"--init-config-path", path.Join(constant.GreptimeDBInitConfigDir, constant.GreptimeDBConfigFileName),
 			"--rpc-port", fmt.Sprintf("%d", b.Cluster.Spec.Flownode.RPCPort),
-			"--service-name", common.ResourceName(b.Cluster.Name, b.RoleKind),
-			"--namespace", b.Cluster.Namespace,
 			"--component-kind", string(b.RoleKind),
 		},
 		VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
## What's changed

1. Use pod ip to set up `--server-addr` in datanode and flownode;
2. Remove some unused arguments of initializer;