### PR TITLE
chore: enable frontend internal rpc port by default

### DIFF
--- a/apis/v1alpha1/constants.go
+++ b/apis/v1alpha1/constants.go
@@ -37,6 +37,9 @@ const (
 	// DefaultMetaRPCPort is the default Meta RPC port for the GreptimeDB.
 	DefaultMetaRPCPort int32 = 3002
 
+	// DefaultFrontendInternalRPCPort is the default Frontend internal RPC port for the GreptimeDB.
+	DefaultFrontendInternalRPCPort int32 = 4010
+
 	// DefaultReplicas is the default number of replicas for components of the GreptimeDB cluster.
 	DefaultReplicas = 1
 

--- a/apis/v1alpha1/defaulting.go
+++ b/apis/v1alpha1/defaulting.go
@@ -200,6 +200,7 @@ func (in *GreptimeDBCluster) defaultFrontend() *FrontendSpec {
 		HTTPPort:       DefaultHTTPPort,
 		MySQLPort:      DefaultMySQLPort,
 		PostgreSQLPort: DefaultPostgreSQLPort,
+		InternalPort:   DefaultFrontendInternalRPCPort,
 		Service: &ServiceSpec{
 			Type: corev1.ServiceTypeClusterIP,
 		},

--- a/apis/v1alpha1/greptimedbcluster_types.go
+++ b/apis/v1alpha1/greptimedbcluster_types.go
@@ -311,7 +311,7 @@ type FrontendSpec struct {
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=65535
 	// +optional
-	InternalPort *int32 `json:"internalPort,omitempty"`
+	InternalPort int32 `json:"internalPort,omitempty"`
 
 	// Service is the service configuration of the frontend.
 	// +optional

--- a/apis/v1alpha1/testdata/defaulting/greptimedbcluster/merge/test01/expect.yaml
+++ b/apis/v1alpha1/testdata/defaulting/greptimedbcluster/merge/test01/expect.yaml
@@ -53,6 +53,7 @@ spec:
     mysqlPort: 4002
     postgreSQLPort: 4003
     rpcPort: 4001
+    internalPort: 4010
     service:
       type: ClusterIP
     slowQuery:

--- a/apis/v1alpha1/testdata/defaulting/greptimedbcluster/merge/test02/expect.yaml
+++ b/apis/v1alpha1/testdata/defaulting/greptimedbcluster/merge/test02/expect.yaml
@@ -143,6 +143,7 @@ spec:
     tracing: {}
     mysqlPort: 4002
     postgreSQLPort: 4003
+    internalPort: 4010
     replicas: 2
     rollingUpdate:
       maxSurge: 25%
@@ -195,6 +196,7 @@ spec:
     tracing: {}
     mysqlPort: 4002
     postgreSQLPort: 4003
+    internalPort: 4010
     replicas: 2
     rollingUpdate:
       maxSurge: 25%

--- a/apis/v1alpha1/testdata/defaulting/greptimedbcluster/merge/test03/expect.yaml
+++ b/apis/v1alpha1/testdata/defaulting/greptimedbcluster/merge/test03/expect.yaml
@@ -150,7 +150,7 @@ spec:
       enabled: true
       endpoint: "trace-endpoint"
       sampleRatio: "0.6"
-    internalPort: 4010
+    internalPort: 5010
     mysqlPort: 4002
     postgreSQLPort: 4003
     replicas: 2
@@ -196,7 +196,7 @@ spec:
           periodSeconds: 5
   - name: write
     httpPort: 4000
-    internalPort: 4010
+    internalPort: 5010
     logging:
       format: text
       level: info

--- a/apis/v1alpha1/testdata/defaulting/greptimedbcluster/merge/test03/input.yaml
+++ b/apis/v1alpha1/testdata/defaulting/greptimedbcluster/merge/test03/input.yaml
@@ -25,7 +25,7 @@ spec:
       enabled: true
       endpoint: "trace-endpoint"
       sampleRatio: "0.6"
-    internalPort: 4010
+    internalPort: 5010
     slowQuery:
       enabled: true
       recordType: system_table
@@ -44,7 +44,7 @@ spec:
       sampleRatio: "0.5"
       threshold: 20s
       ttl: 20d
-    internalPort: 4010
+    internalPort: 5010
   meta:
     backendStorage:
       etcd:

--- a/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test00/expect.yaml
+++ b/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test00/expect.yaml
@@ -45,6 +45,7 @@ spec:
     mysqlPort: 4002
     postgreSQLPort: 4003
     rpcPort: 4001
+    internalPort: 4010
     service:
       type: ClusterIP
     logging: {}

--- a/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test01/expect.yaml
+++ b/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test01/expect.yaml
@@ -52,6 +52,7 @@ spec:
     mysqlPort: 4002
     postgreSQLPort: 4003
     rpcPort: 4001
+    internalPort: 4010
     service:
       type: ClusterIP
     logging: {}

--- a/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test02/expect.yaml
+++ b/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test02/expect.yaml
@@ -56,6 +56,7 @@ spec:
     mysqlPort: 4002
     postgreSQLPort: 4003
     rpcPort: 4001
+    internalPort: 4010
     service:
       type: ClusterIP
     logging: {}

--- a/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test03/expect.yaml
+++ b/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test03/expect.yaml
@@ -52,6 +52,7 @@ spec:
     rpcPort: 4001
     mysqlPort: 4002
     postgreSQLPort: 4003
+    internalPort: 4010
     service:
       type: ClusterIP
     logging: {}

--- a/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test04/expect.yaml
+++ b/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test04/expect.yaml
@@ -46,6 +46,7 @@ spec:
     mysqlPort: 6002
     postgreSQLPort: 6003
     rpcPort: 6001
+    internalPort: 5010
     service:
       type: ClusterIP
     slowQuery:
@@ -65,6 +66,7 @@ spec:
     httpPort: 7000
     mysqlPort: 7002
     postgreSQLPort: 7003
+    internalPort: 5010
     rpcPort: 7001
     logging: {}
     tracing: {}

--- a/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test04/input.yaml
+++ b/apis/v1alpha1/testdata/defaulting/greptimedbcluster/setdefaults/test04/input.yaml
@@ -16,6 +16,7 @@ spec:
     postgreSQLPort: 6003
     rpcPort: 6001
     httpPort: 6000
+    internalPort: 5010
     rollingUpdate:
       maxSurge: 25%
       maxUnavailable: 25%
@@ -27,6 +28,7 @@ spec:
     postgreSQLPort: 7003
     rpcPort: 7001
     httpPort: 7000
+    internalPort: 5010
     rollingUpdate:
       maxSurge: 50%
       maxUnavailable: 50%

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -312,11 +312,6 @@ func (in *FlownodeStatus) DeepCopy() *FlownodeStatus {
 func (in *FrontendSpec) DeepCopyInto(out *FrontendSpec) {
 	*out = *in
 	in.ComponentSpec.DeepCopyInto(&out.ComponentSpec)
-	if in.InternalPort != nil {
-		in, out := &in.InternalPort, &out.InternalPort
-		*out = new(int32)
-		**out = **in
-	}
 	if in.Service != nil {
 		in, out := &in.Service, &out.Service
 		*out = new(ServiceSpec)

--- a/controllers/greptimedbcluster/deployers/frontend.go
+++ b/controllers/greptimedbcluster/deployers/frontend.go
@@ -412,6 +412,8 @@ func (b *frontendBuilder) generateMainContainerArgs(frontend *v1alpha1.FrontendS
 		"--mysql-addr", fmt.Sprintf("0.0.0.0:%d", frontend.MySQLPort),
 		"--postgres-addr", fmt.Sprintf("0.0.0.0:%d", frontend.PostgreSQLPort),
 		"--config-file", path.Join(constant.GreptimeDBConfigDir, constant.GreptimeDBConfigFileName),
+		"--internal-rpc-bind-addr", fmt.Sprintf("0.0.0.0:%d", frontend.InternalPort),
+		"--internal-rpc-server-addr", fmt.Sprintf("$(%s):%d", deployer.EnvPodIP, frontend.InternalPort),
 	}
 
 	if frontend.TLS != nil {
@@ -419,13 +421,6 @@ func (b *frontendBuilder) generateMainContainerArgs(frontend *v1alpha1.FrontendS
 			"--tls-mode", constant.DefaultTLSMode,
 			"--tls-cert-path", path.Join(constant.GreptimeDBTLSDir, v1alpha1.TLSCrtSecretKey),
 			"--tls-key-path", path.Join(constant.GreptimeDBTLSDir, v1alpha1.TLSKeySecretKey),
-		}...)
-	}
-
-	if frontend.InternalPort != nil {
-		args = append(args, []string{
-			"--internal-rpc-bind-addr", fmt.Sprintf("0.0.0.0:%d", *frontend.InternalPort),
-			"--internal-rpc-server-addr", fmt.Sprintf("$(%s):%d", deployer.EnvPodIP, *frontend.InternalPort),
 		}...)
 	}
 
@@ -538,16 +533,11 @@ func (b *frontendBuilder) containerPorts(frontend *v1alpha1.FrontendSpec) []core
 			Protocol:      corev1.ProtocolTCP,
 			ContainerPort: frontend.PostgreSQLPort,
 		},
-	}
-
-	if frontend.InternalPort != nil {
-		ports = append(ports, []corev1.ContainerPort{
-			{
-				Name:          "internal-rpc",
-				Protocol:      corev1.ProtocolTCP,
-				ContainerPort: *frontend.InternalPort,
-			},
-		}...)
+		{
+			Name:          "internal-rpc",
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: frontend.InternalPort,
+		},
 	}
 
 	return ports

--- a/tests/e2e/testdata/sql/cluster/flow_basic.sql
+++ b/tests/e2e/testdata/sql/cluster/flow_basic.sql
@@ -1,6 +1,6 @@
 -- FIXME(liyang): The test cases from: https://github.com/GreptimeTeam/greptimedb/blob/main/tests/cases/standalone/common/flow/flow_user_guide.sql
 
-CREATE TABLE `ngx_access_log` (
+CREATE TABLE ngx_access_log (
     "client" STRING NULL,
     "ua_platform" STRING NULL,
     "referer" STRING NULL,
@@ -15,7 +15,7 @@ CREATE TABLE `ngx_access_log` (
     TIME INDEX (access_time)
 ) WITH(append_mode = 'true');
 
-CREATE TABLE `ngx_statistics` (
+CREATE TABLE ngx_statistics (
     "status" SMALLINT UNSIGNED NULL,
     "total_logs" BIGINT NULL,
     "min_size" DOUBLE NULL,
@@ -36,7 +36,7 @@ SELECT
     avg(size) as avg_size,
     sum(
         case
-            when `size` > 550 then 1
+            when size > 550 then 1
             else 0
         end
     ) as high_size_count,
@@ -354,7 +354,7 @@ DROP TABLE temp_alerts;
 CREATE TABLE ngx_access_log (
     client STRING,
     stat INT,
-    "size" INT,
+    size INT,
     access_time TIMESTAMP TIME INDEX
 );
 

--- a/tests/e2e/testdata/sql/cluster/flow_basic.sql
+++ b/tests/e2e/testdata/sql/cluster/flow_basic.sql
@@ -1,30 +1,30 @@
 -- FIXME(liyang): The test cases from: https://github.com/GreptimeTeam/greptimedb/blob/main/tests/cases/standalone/common/flow/flow_user_guide.sql.
 
 CREATE TABLE `ngx_access_log` (
-    `client` STRING NULL,
-    `ua_platform` STRING NULL,
-    `referer` STRING NULL,
-    `method` STRING NULL,
-    `endpoint` STRING NULL,
-    `trace_id` STRING NULL FULLTEXT INDEX,
-    `protocol` STRING NULL,
-    `status` SMALLINT UNSIGNED NULL,
-    `size` DOUBLE NULL,
-    `agent` STRING NULL,
-    `access_time` TIMESTAMP(3) NOT NULL,
-    TIME INDEX (`access_time`)
+    "client" STRING NULL,
+    "ua_platform" STRING NULL,
+    "referer" STRING NULL,
+    "method" STRING NULL,
+    "endpoint" STRING NULL,
+    "trace_id" STRING NULL FULLTEXT INDEX,
+    "protocol" STRING NULL,
+    "status" SMALLINT UNSIGNED NULL,
+    "size" DOUBLE NULL,
+    "agent" STRING NULL,
+    "access_time" TIMESTAMP(3) NOT NULL,
+    TIME INDEX (access_time)
 ) WITH(append_mode = 'true');
 
 CREATE TABLE `ngx_statistics` (
-    `status` SMALLINT UNSIGNED NULL,
-    `total_logs` BIGINT NULL,
-    `min_size` DOUBLE NULL,
-    `max_size` DOUBLE NULL,
-    `avg_size` DOUBLE NULL,
-    `high_size_count` BIGINT NULL,
-    `time_window` TIMESTAMP time index,
-    `update_at` TIMESTAMP NULL,
-    PRIMARY KEY (`status`)
+    "status" SMALLINT UNSIGNED NULL,
+    "total_logs" BIGINT NULL,
+    "min_size" DOUBLE NULL,
+    "max_size" DOUBLE NULL,
+    "avg_size" DOUBLE NULL,
+    "high_size_count" BIGINT NULL,
+    "time_window" TIMESTAMP time index,
+    "update_at" TIMESTAMP NULL,
+    PRIMARY KEY (status)
 );
 
 CREATE FLOW ngx_aggregation SINK TO ngx_statistics COMMENT 'Aggregate statistics for ngx_access_log' AS

--- a/tests/e2e/testdata/sql/cluster/flow_basic.sql
+++ b/tests/e2e/testdata/sql/cluster/flow_basic.sql
@@ -1,44 +1,48 @@
 -- FIXME(liyang): The test cases from: https://github.com/GreptimeTeam/greptimedb/blob/main/tests/cases/standalone/common/flow/flow_user_guide.sql.
 
-CREATE TABLE ngx_access_log (
-    "client" STRING NULL,
-    "ua_platform" STRING NULL,
-    "referer" STRING NULL,
-    "method" STRING NULL,
-    "endpoint" STRING NULL,
-    "trace_id" STRING NULL FULLTEXT INDEX,
-    "protocol" STRING NULL,
-    "status" SMALLINT UNSIGNED NULL,
-    "size" DOUBLE NULL,
-    "agent" STRING NULL,
-    "access_time" TIMESTAMP(3) NOT NULL,
-    TIME INDEX (access_time)
+CREATE TABLE `ngx_access_log` (
+    `client` STRING NULL,
+    `ua_platform` STRING NULL,
+    `referer` STRING NULL,
+    `method` STRING NULL,
+    `endpoint` STRING NULL,
+    `trace_id` STRING NULL FULLTEXT INDEX,
+    `protocol` STRING NULL,
+    `status` SMALLINT UNSIGNED NULL,
+    `size` DOUBLE NULL,
+    `agent` STRING NULL,
+    `access_time` TIMESTAMP(3) NOT NULL,
+    TIME INDEX (`access_time`)
 ) WITH(append_mode = 'true');
 
-CREATE TABLE ngx_statistics (
-    "status" SMALLINT UNSIGNED NULL,
-    "total_logs" BIGINT NULL,
-    "min_size" DOUBLE NULL,
-    "max_size" DOUBLE NULL,
-    "avg_size" DOUBLE NULL,
-    "high_size_count" BIGINT NULL,
-    "time_window" TIMESTAMP time index,
-    "update_at" TIMESTAMP NULL,
-    PRIMARY KEY (status)
+CREATE TABLE `ngx_statistics` (
+    `status` SMALLINT UNSIGNED NULL,
+    `total_logs` BIGINT NULL,
+    `min_size` DOUBLE NULL,
+    `max_size` DOUBLE NULL,
+    `avg_size` DOUBLE NULL,
+    `high_size_count` BIGINT NULL,
+    `time_window` TIMESTAMP time index,
+    `update_at` TIMESTAMP NULL,
+    PRIMARY KEY (`status`)
 );
 
-CREATE FLOW ngx_aggregation
-SINK TO ngx_statistics
-AS
+CREATE FLOW ngx_aggregation SINK TO ngx_statistics COMMENT 'Aggregate statistics for ngx_access_log' AS
 SELECT
     status,
     count(client) AS total_logs,
     min(size) as min_size,
     max(size) as max_size,
     avg(size) as avg_size,
-    sum(case when size > 550 then 1 else 0 end) as high_size_count,
-    date_bin(INTERVAL '1' MINUTE, access_time) as time_window,
-FROM ngx_access_log
+    sum(
+        case
+            when `size` > 550 then 1
+            else 0
+        end
+    ) as high_size_count,
+    date_bin(INTERVAL '1 minutes', access_time) as time_window,
+FROM
+    ngx_access_log
 GROUP BY
     status,
     time_window;
@@ -236,7 +240,7 @@ CREATE TABLE ngx_country (
 CREATE FLOW calc_ngx_country SINK TO ngx_country AS
 SELECT
     DISTINCT country,
-    date_bin(INTERVAL '1' hour, access_time) as time_window,
+    date_bin(INTERVAL '1 hour', access_time) as time_window,
 FROM
     ngx_access_log
 GROUP BY
@@ -288,7 +292,7 @@ CREATE TABLE temp_alerts (
     sensor_id INT,
     loc STRING,
     max_temp DOUBLE,
-    update_at TIMESTAMP TIME INDEX,
+    event_ts TIMESTAMP TIME INDEX,
     PRIMARY KEY(sensor_id, loc)
 );
 
@@ -297,6 +301,7 @@ SELECT
     sensor_id,
     loc,
     max(temperature) as max_temp,
+    max(ts) as event_ts,
 FROM
     temp_sensor_data
 GROUP BY
@@ -317,7 +322,8 @@ ADMIN FLUSH_FLOW('temp_monitoring');
 SELECT
     sensor_id,
     loc,
-    max_temp
+    max_temp,
+    event_ts
 FROM
     temp_alerts;
 
@@ -334,7 +340,8 @@ ADMIN FLUSH_FLOW('temp_monitoring');
 SELECT
     sensor_id,
     loc,
-    max_temp
+    max_temp,
+    event_ts
 FROM
     temp_alerts;
 
@@ -347,7 +354,7 @@ DROP TABLE temp_alerts;
 CREATE TABLE ngx_access_log (
     client STRING,
     stat INT,
-    size INT,
+    "size" INT,
     access_time TIMESTAMP TIME INDEX
 );
 
@@ -368,7 +375,7 @@ SELECT
     stat,
     trunc(size, -1) :: INT as bucket_size,
     count(client) AS total_logs,
-    date_bin(INTERVAL '1' minute, access_time) as time_window,
+    date_bin(INTERVAL '1 minutes', access_time) as time_window,
 FROM
     ngx_access_log
 GROUP BY

--- a/tests/e2e/testdata/sql/cluster/flow_basic.sql
+++ b/tests/e2e/testdata/sql/cluster/flow_basic.sql
@@ -353,8 +353,8 @@ DROP TABLE temp_alerts;
 /* create input table */
 CREATE TABLE ngx_access_log (
     client STRING,
-    stat INT,
-    size INT,
+    stat   INT,
+    "size" INT,
     access_time TIMESTAMP TIME INDEX
 );
 

--- a/tests/e2e/testdata/sql/cluster/flow_basic.sql
+++ b/tests/e2e/testdata/sql/cluster/flow_basic.sql
@@ -1,4 +1,4 @@
--- FIXME(liyang): The test cases from: https://github.com/GreptimeTeam/greptimedb/blob/main/tests/cases/standalone/common/flow/flow_user_guide.sql.
+-- FIXME(liyang): The test cases from: https://github.com/GreptimeTeam/greptimedb/blob/main/tests/cases/standalone/common/flow/flow_user_guide.sql
 
 CREATE TABLE `ngx_access_log` (
     "client" STRING NULL,
@@ -40,7 +40,7 @@ SELECT
             else 0
         end
     ) as high_size_count,
-    date_bin(INTERVAL '1 minutes', access_time) as time_window,
+    date_bin(INTERVAL '1' minutes, access_time) as time_window,
 FROM
     ngx_access_log
 GROUP BY
@@ -240,7 +240,7 @@ CREATE TABLE ngx_country (
 CREATE FLOW calc_ngx_country SINK TO ngx_country AS
 SELECT
     DISTINCT country,
-    date_bin(INTERVAL '1 hour', access_time) as time_window,
+    date_bin(INTERVAL '1' hour, access_time) as time_window,
 FROM
     ngx_access_log
 GROUP BY
@@ -375,7 +375,7 @@ SELECT
     stat,
     trunc(size, -1) :: INT as bucket_size,
     count(client) AS total_logs,
-    date_bin(INTERVAL '1 minutes', access_time) as time_window,
+    date_bin(INTERVAL '1' minutes, access_time) as time_window,
 FROM
     ngx_access_log
 GROUP BY


### PR DESCRIPTION
If `internal-port` is not enabled, calls from internal the cluster will use the external port instead of the internal gRPC port, but the external port may require authentication.

related to: https://github.com/GreptimeTeam/greptimedb-operator/pull/324