### PR TITLE
feat: supprt `IsUseEmptyDir` for monitoring standalone storage

### DIFF
--- a/controllers/greptimedbstandalone/deployer.go
+++ b/controllers/greptimedbstandalone/deployer.go
@@ -22,6 +22,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
@@ -96,9 +97,14 @@ func (d *StandaloneDeployer) CleanUp(ctx context.Context, crdObject client.Objec
 		return err
 	}
 
-	if standalone.GetDatanodeFileStorage().GetPolicy() == v1alpha1.StorageRetainPolicyTypeDelete {
-		if err := d.deleteStorage(ctx, standalone.Namespace, common.ResourceName(standalone.Name, v1alpha1.StandaloneRoleKind), common.FileStorageTypeDatanode); err != nil {
-			return err
+	if fs := standalone.GetDatanodeFileStorage(); fs != nil {
+		if fs.IsUseEmptyDir() {
+			return nil
+		}
+		if fs.GetPolicy() == v1alpha1.StorageRetainPolicyTypeDelete {
+			if err := d.deleteStorage(ctx, standalone.Namespace, common.ResourceName(standalone.Name, v1alpha1.StandaloneRoleKind), common.FileStorageTypeDatanode); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -262,13 +268,16 @@ func (b *standaloneBuilder) BuildStatefulSet() deployer.Builder {
 					constant.GreptimeDBComponentName: common.ResourceName(b.standalone.Name, v1alpha1.StandaloneRoleKind),
 				},
 			},
-			Template:             b.generatePodTemplateSpec(),
-			VolumeClaimTemplates: b.generatePVCs(),
+			Template: b.generatePodTemplateSpec(),
 			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 				Type:          appsv1.RollingUpdateStatefulSetStrategyType,
 				RollingUpdate: b.standalone.Spec.RollingUpdate,
 			},
 		},
+	}
+
+	if !b.standalone.GetDatanodeFileStorage().IsUseEmptyDir() {
+		sts.Spec.VolumeClaimTemplates = b.generatePVCs()
 	}
 
 	configData, err := dbconfig.FromStandalone(b.standalone)
@@ -318,6 +327,10 @@ func (b *standaloneBuilder) generatePodTemplateSpec() corev1.PodTemplateSpec {
 	}
 
 	b.addVolumeMounts(template)
+
+	if b.standalone.GetDatanodeFileStorage().IsUseEmptyDir() {
+		b.addEmptyDirAsStorage(template, b.standalone)
+	}
 
 	template.Spec.Containers[constant.MainContainerIndex].Ports = b.containerPorts()
 	template.Labels = util.MergeStringMap(template.Labels, map[string]string{
@@ -489,4 +502,16 @@ func (b *standaloneBuilder) addVolumeMounts(template *corev1.PodTemplateSpec) {
 			MountPath: logging.GetLogsDir(),
 		})
 	}
+}
+
+func (b *standaloneBuilder) addEmptyDirAsStorage(template *corev1.PodTemplateSpec, spec *v1alpha1.GreptimeDBStandalone) {
+	storageSize := resource.MustParse(spec.GetDatanodeFileStorage().GetSize())
+	template.Spec.Volumes = append(template.Spec.Volumes, corev1.Volume{
+		Name: spec.GetDatanodeFileStorage().GetName(),
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{
+				SizeLimit: &storageSize,
+			},
+		},
+	})
 }

--- a/tests/e2e/greptimedbstandalone/test_cluster_with_emptydir.go
+++ b/tests/e2e/greptimedbstandalone/test_cluster_with_emptydir.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package greptimedbstandalone
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	greptimev1alpha1 "github.com/GreptimeTeam/greptimedb-operator/apis/v1alpha1"
+	"github.com/GreptimeTeam/greptimedb-operator/controllers/common"
+	"github.com/GreptimeTeam/greptimedb-operator/tests/e2e/helper"
+)
+
+// TestClusterWithEmptyDir tests a standalone with empty dir..
+func TestClusterWithEmptyDir(ctx context.Context, h *helper.Helper) {
+	const (
+		testCRFile  = "./testdata/resources/standalone/use-empty-dir/standalone.yaml"
+		testSQLFile = "./testdata/sql/standalone/basic.sql"
+	)
+
+	By(fmt.Sprintf("greptimestandalone test with CR file %s and SQL file %s", testCRFile, testSQLFile))
+
+	testStandalone := new(greptimev1alpha1.GreptimeDBStandalone)
+	err := h.LoadCR(testCRFile, testStandalone)
+	Expect(err).NotTo(HaveOccurred(), "failed to load greptime crd from file")
+
+	err = h.Create(ctx, testStandalone)
+	Expect(err).NotTo(HaveOccurred(), "failed to create greptimedbstandalone")
+
+	By("Check the status of testStandalone")
+	Eventually(func() error {
+		phase, err := h.GetPhase(ctx, testStandalone.Namespace, testStandalone.Name, new(greptimev1alpha1.GreptimeDBStandalone))
+		if err != nil {
+			return err
+		}
+
+		if phase != greptimev1alpha1.PhaseRunning {
+			return fmt.Errorf("standalone is not running")
+		}
+
+		return nil
+	}, helper.DefaultTimeout, time.Second).ShouldNot(HaveOccurred())
+
+	err = h.Get(ctx, client.ObjectKey{Name: testStandalone.Name, Namespace: testStandalone.Namespace}, testStandalone)
+	Expect(err).NotTo(HaveOccurred(), "failed to get standalone")
+
+	By("Run SQL test")
+	frontendAddr, err := h.PortForward(ctx, testStandalone.Namespace, common.ResourceName(testStandalone.Name, greptimev1alpha1.StandaloneRoleKind), int(testStandalone.Spec.PostgreSQLPort))
+	Expect(err).NotTo(HaveOccurred(), "failed to port forward frontend service")
+	Eventually(func() error {
+		conn, err := net.Dial("tcp", frontendAddr)
+		if err != nil {
+			return err
+		}
+		conn.Close()
+		return nil
+	}, helper.DefaultTimeout, time.Second).ShouldNot(HaveOccurred())
+
+	err = h.RunSQLTest(ctx, frontendAddr, testSQLFile)
+	Expect(err).NotTo(HaveOccurred(), "failed to run sql test")
+
+	By("Kill the port forwarding process")
+	h.KillPortForwardProcess()
+
+	By("Delete standalone")
+	err = h.Delete(ctx, testStandalone)
+	Expect(err).NotTo(HaveOccurred(), "failed to delete standalone")
+	Eventually(func() error {
+		// The standalone will be deleted eventually.
+		return h.Get(ctx, client.ObjectKey{Name: testStandalone.Name, Namespace: testStandalone.Namespace}, testStandalone)
+	}, helper.DefaultTimeout, time.Second).Should(HaveOccurred())
+
+	By("The PVC of the database should be retained")
+	dataPVCs, err := h.GetPVCs(ctx, testStandalone.Namespace, common.ResourceName(testStandalone.Name, greptimev1alpha1.StandaloneRoleKind), common.FileStorageTypeDatanode)
+	Expect(err).NotTo(HaveOccurred(), "failed to get data PVCs")
+	Expect(len(dataPVCs)).To(Equal(1), "the number of datanode PVCs should be equal to 1")
+
+	By("Remove the PVC of the datanode")
+	for _, pvc := range dataPVCs {
+		err = h.Delete(ctx, &pvc)
+		Expect(err).NotTo(HaveOccurred(), "failed to delete data PVCs")
+	}
+}

--- a/tests/e2e/greptimedbstandalone/test_cluster_with_emptydir.go
+++ b/tests/e2e/greptimedbstandalone/test_cluster_with_emptydir.go
@@ -89,14 +89,8 @@ func TestClusterWithEmptyDir(ctx context.Context, h *helper.Helper) {
 		return h.Get(ctx, client.ObjectKey{Name: testStandalone.Name, Namespace: testStandalone.Namespace}, testStandalone)
 	}, helper.DefaultTimeout, time.Second).Should(HaveOccurred())
 
-	By("The PVC of the database should be retained")
+	By("The PVC of the database should be null")
 	dataPVCs, err := h.GetPVCs(ctx, testStandalone.Namespace, common.ResourceName(testStandalone.Name, greptimev1alpha1.StandaloneRoleKind), common.FileStorageTypeDatanode)
 	Expect(err).NotTo(HaveOccurred(), "failed to get data PVCs")
-	Expect(len(dataPVCs)).To(Equal(1), "the number of datanode PVCs should be equal to 1")
-
-	By("Remove the PVC of the datanode")
-	for _, pvc := range dataPVCs {
-		err = h.Delete(ctx, &pvc)
-		Expect(err).NotTo(HaveOccurred(), "failed to delete data PVCs")
-	}
+	Expect(len(dataPVCs)).To(Equal(0), "the number of datanode PVCs should be equal to 0")
 }

--- a/tests/e2e/greptimedbstandalone_test.go
+++ b/tests/e2e/greptimedbstandalone_test.go
@@ -30,4 +30,7 @@ var _ = Describe("Test GreptimeDBStandalone", func() {
 	It("Test a basic standalone", func() {
 		greptimedbstandalone.TestBasicStandalone(ctx, h)
 	})
+	It("Test a standalone with empty dir", func() {
+		greptimedbstandalone.TestClusterWithEmptyDir(ctx, h)
+	})
 })

--- a/tests/e2e/testdata/resources/standalone/use-empty-dir/standalone.yaml
+++ b/tests/e2e/testdata/resources/standalone/use-empty-dir/standalone.yaml
@@ -1,0 +1,13 @@
+apiVersion: greptime.io/v1alpha1
+kind: GreptimeDBStandalone
+metadata:
+  name: e2e-standalone-use-empty-dir
+  namespace: default
+spec:
+  base:
+    main:
+      image: greptime/greptimedb:latest
+  datanodeStorage:
+    fs:
+      useEmptyDir: true
+      storageSize: 10Gi


### PR DESCRIPTION
Supports mounting [emptydir type storage](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) volumes on greptimedb standalone instances.


example:
```
apiVersion: greptime.io/v1alpha1
kind: GreptimeDBCluster
metadata:
  name: basic
spec:
  base:
    main:
      image: greptime/greptimedb:latest
  frontend:
    replicas: 1
  meta:
    replicas: 1
    backendStorage:
      etcd:
        endpoints:
          - "etcd.etcd-cluster.svc.cluster.local:2379"
  datanode:
    replicas: 1
    storage:
      fs:
        storageSize: 10Gi
        useEmptyDir: true
  monitoring:
    enabled: true
    standalone:
      base:
        main:
          image: greptime/greptimedb:latest
      datanodeStorage:
        fs:
          useEmptyDir: true
          storageSize: 10Gi
```