### PR TITLE
refactor: set meta maintenance mode

### DIFF
--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -317,7 +317,13 @@ func GetMetaHTTPServiceURL(cluster *v1alpha1.GreptimeDBCluster) string {
 
 // SetMaintenanceMode requests the metasrv to set the maintenance mode.
 func SetMaintenanceMode(metaHTTPServiceURL string, enabled bool) error {
-	requestURL := fmt.Sprintf("%s/admin/maintenance?enable=%v", metaHTTPServiceURL, enabled)
+	var endpoint = map[bool]string{
+		true:  "/admin/maintenance/enable",
+		false: "/admin/maintenance/disable",
+	}
+
+	// Related to: https://docs.greptime.com/user-guide/deployments-administration/maintenance/maintenance-mode/#managing-maintenance-mode
+	requestURL := metaHTTPServiceURL + endpoint[enabled]
 
 	operation := func() error {
 		rsp, err := http.Get(requestURL)

--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -326,7 +326,7 @@ func SetMaintenanceMode(metaHTTPServiceURL string, enabled bool) error {
 	requestURL := metaHTTPServiceURL + endpoint[enabled]
 
 	operation := func() error {
-		rsp, err := http.Get(requestURL)
+		rsp, err := http.Post(requestURL, "application/json", nil)
 		if err != nil {
 			return err
 		}

--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -312,7 +312,7 @@ func LogsPipelineName(namespace, name string) string {
 }
 
 func GetMetaHTTPServiceURL(cluster *v1alpha1.GreptimeDBCluster) string {
-	return fmt.Sprintf("http://%s.%s:%d", ResourceName(cluster.GetName(), v1alpha1.MetaRoleKind), cluster.GetNamespace(), cluster.Spec.Meta.RPCPort)
+	return fmt.Sprintf("http://%s.%s:%d", ResourceName(cluster.GetName(), v1alpha1.MetaRoleKind), cluster.GetNamespace(), cluster.Spec.Meta.HTTPPort)
 }
 
 // SetMaintenanceMode requests the metasrv to set the maintenance mode.


### PR DESCRIPTION
The old interface is deprecated, refer to the new interface: https://docs.greptime.com/user-guide/deployments-administration/maintenance/maintenance-mode/#managing-maintenance-mode

<img width="2676" height="248" alt="image" src="https://github.com/user-attachments/assets/a9c15ef8-047c-4184-b68b-9bbe3f1c10ee" />
