### PR TITLE
fix: frontend groups audit log

### DIFF
--- a/controllers/greptimedbcluster/deployers/common.go
+++ b/controllers/greptimedbcluster/deployers/common.go
@@ -160,21 +160,6 @@ func (c *CommonBuilder) AddAuditLogsVolumeForVector(template *corev1.PodTemplate
 	})
 }
 
-// shouldEnableAuditLogs checks if any frontend component has audit logging enabled.
-func (c *CommonBuilder) shouldEnableAuditLogs() bool {
-	if c.Cluster.GetFrontend() != nil {
-		if auditLog := c.Cluster.GetFrontend().GetAuditLog(); auditLog != nil && auditLog.Enabled {
-			return true
-		}
-	}
-	for _, fg := range c.Cluster.GetFrontendGroups() {
-		if auditLog := fg.GetAuditLog(); auditLog != nil && auditLog.Enabled {
-			return true
-		}
-	}
-	return false
-}
-
 func (c *CommonBuilder) AddVectorConfigVolume(template *corev1.PodTemplateSpec) {
 	template.Spec.Volumes = append(template.Spec.Volumes, corev1.Volume{
 		Name: constant.DefaultVectorConfigName,
@@ -237,7 +222,7 @@ func (c *CommonBuilder) GenerateVectorConfigMap() (*corev1.ConfigMap, error) {
 		"MetricService":         fmt.Sprintf("http://%s:%d/v1/prometheus/write?db=public", svc, v1alpha1.DefaultHTTPPort),
 		"TTL":                   c.Cluster.GetMonitoring().TTL,
 		"PodIP":                 "${POD_IP}",
-		"EnableAuditLogs":       fmt.Sprintf("%v", c.shouldEnableAuditLogs()),
+		"EnableAuditLogs":       fmt.Sprintf("%v", IsAuditLogEnabled(c.Cluster)),
 	}
 	if c.Cluster.Spec.EnableIPv6 {
 		vars["MetricsEndpoint"] = fmt.Sprintf("http://[${POD_IP}]:%d/metrics", v1alpha1.DefaultHTTPPort)
@@ -345,4 +330,19 @@ func UpdateStatus(ctx context.Context, input *v1alpha1.GreptimeDBCluster, kc cli
 		cluster.Status = status
 		return kc.Status().Update(ctx, cluster, opts...)
 	})
+}
+
+// IsAuditLogEnabled checks if any frontend component has audit logging enabled.
+func IsAuditLogEnabled(cluster *v1alpha1.GreptimeDBCluster) bool {
+	if cluster.GetFrontend() != nil {
+		if auditLog := cluster.GetFrontend().GetAuditLog(); auditLog != nil && auditLog.Enabled {
+			return true
+		}
+	}
+	for _, fg := range cluster.GetFrontendGroups() {
+		if auditLog := fg.GetAuditLog(); auditLog != nil && auditLog.Enabled {
+			return true
+		}
+	}
+	return false
 }

--- a/controllers/greptimedbcluster/deployers/monitoring.go
+++ b/controllers/greptimedbcluster/deployers/monitoring.go
@@ -213,7 +213,7 @@ func (d *MonitoringDeployer) pipelines(cluster *v1alpha1.GreptimeDBCluster) ([]*
 	}
 
 	// Only create audit logs pipeline if audit logging is enabled.
-	if d.isAuditLogEnabled(cluster) {
+	if IsAuditLogEnabled(cluster) {
 		auditLogsPipeline, err := d.defaultAuditLogsPipeline()
 		if err != nil {
 			return nil, err
@@ -225,19 +225,6 @@ func (d *MonitoringDeployer) pipelines(cluster *v1alpha1.GreptimeDBCluster) ([]*
 	}
 
 	return pipelines, nil
-}
-
-// isAuditLogEnabled checks whether audit log is enabled on the frontend or any frontend group.
-func (d *MonitoringDeployer) isAuditLogEnabled(cluster *v1alpha1.GreptimeDBCluster) bool {
-	if auditLog := cluster.GetFrontend().GetAuditLog(); auditLog != nil && auditLog.Enabled {
-		return true
-	}
-	for _, frontend := range cluster.GetFrontendGroups() {
-		if auditLog := frontend.GetAuditLog(); auditLog != nil && auditLog.Enabled {
-			return true
-		}
-	}
-	return false
 }
 
 // defaultLogsPipeline returns the default pipeline that will be used by the standalone greptimedb instance to collect greptimedb logs.

--- a/controllers/greptimedbcluster/deployers/monitoring.go
+++ b/controllers/greptimedbcluster/deployers/monitoring.go
@@ -213,7 +213,7 @@ func (d *MonitoringDeployer) pipelines(cluster *v1alpha1.GreptimeDBCluster) ([]*
 	}
 
 	// Only create audit logs pipeline if audit logging is enabled.
-	if auditLog := cluster.GetFrontend().GetAuditLog(); auditLog != nil && auditLog.Enabled {
+	if d.isAuditLogEnabled(cluster) {
 		auditLogsPipeline, err := d.defaultAuditLogsPipeline()
 		if err != nil {
 			return nil, err
@@ -225,6 +225,19 @@ func (d *MonitoringDeployer) pipelines(cluster *v1alpha1.GreptimeDBCluster) ([]*
 	}
 
 	return pipelines, nil
+}
+
+// isAuditLogEnabled checks whether audit log is enabled on the frontend or any frontend group.
+func (d *MonitoringDeployer) isAuditLogEnabled(cluster *v1alpha1.GreptimeDBCluster) bool {
+	if auditLog := cluster.GetFrontend().GetAuditLog(); auditLog != nil && auditLog.Enabled {
+		return true
+	}
+	for _, frontend := range cluster.GetFrontendGroups() {
+		if auditLog := frontend.GetAuditLog(); auditLog != nil && auditLog.Enabled {
+			return true
+		}
+	}
+	return false
 }
 
 // defaultLogsPipeline returns the default pipeline that will be used by the standalone greptimedb instance to collect greptimedb logs.


### PR DESCRIPTION
 # Summary                                                                                                                                                        
                                                                                                                                                                
 Fix audit log monitoring pipeline not being created when audit logging is only enabled on frontend groups (not the main frontend).                             
                                                                                                                                                                
 # Problem                                                                                                                                                        
                                                                                                                                                                
 Previously, the pipelines method in MonitoringDeployer only checked whether audit logging was enabled on the main frontend:                                    
                                                                                                                                                                
 ```go                                                                                                                                                          
   if auditLog := cluster.GetFrontend().GetAuditLog(); auditLog != nil && auditLog.Enabled {                                                                    
 ```                                                                                                                                                            
                                                                                                                                                                
 This meant that if audit logging was configured only on one or more frontend groups (via frontendGroups), the audit log monitoring pipeline would never be     
 created, even though audit logs were actually being generated.                                                                                                 
                                                                                                                                                                
 # Solution                                                                                                                                                       
                                                                                                                                                                
 Extracted the audit log check into a dedicated isAuditLogEnabled helper method that checks both:                                                               
                                                                                                                                                                
 - The main frontend (cluster.GetFrontend())                                                                                                                    
 - All frontend groups (cluster.GetFrontendGroups())                                                                                                            
                                                                                                                                                                
 Returns true if any of them has audit logging enabled.                                                                                                         
                                                                                                                                                                
 # Changes                                                                                                                                                        
                                                                                                                                                                
 - controllers/greptimedbcluster/deployers/monitoring.go — Introduced isAuditLogEnabled() method and updated pipelines() to use it.                             
                                                                                                                                                                